### PR TITLE
Add docs/conventions.md and bootstrap .github/ templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# CODEOWNERS file for the northwatch repository.
+# Defines code ownership for automatic PR review assignment.
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner for all files and directories
+* @demisx

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,26 @@
+---
+name: Bug
+about: Something isn't working as expected.
+title: ""
+type: bug
+assignees: "demisx"
+labels: ""
+---
+
+## What Happened
+
+...
+
+## Steps to Replicate
+
+1.
+2.
+3.
+
+## Logs / errors
+
+...
+
+## Tasks
+
+- [ ] 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,22 @@
+---
+name: Epic
+about: A high-level initiative that will be broken down into sub-issues.
+title: ""
+type: epic
+assignees: "demisx"
+labels: ""
+---
+
+## Goal
+
+## Scope
+
+**In scope:**
+- ...
+
+**Out of scope:**
+- ...
+
+## Acceptance criteria
+
+- [ ]

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,21 @@
+---
+name: Feature
+about: A new capability or enhancement.
+title: ""
+type: feature
+assignees: "demisx"
+labels: ""
+---
+
+## Description
+
+## Acceptance criteria
+
+- [ ]
+
+## Tech Notes
+- ...
+
+## Tasks
+
+- [ ] 

--- a/.github/ISSUE_TEMPLATE/spike.md
+++ b/.github/ISSUE_TEMPLATE/spike.md
@@ -1,0 +1,20 @@
+---
+name: Spike
+about: Timeboxed research or investigation to reduce uncertainty.
+title: ""
+type: spike
+assignees: "demisx"
+labels: ""
+---
+
+## Question
+
+...
+
+## Context
+
+...
+
+## Expected output
+
+...

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,20 @@
+---
+name: Task
+about: A unit of work.
+title: ""
+type: task
+assignees: "demisx"
+labels: ""
+---
+
+## Description
+
+...
+
+## Tech Notes
+
+- ...
+
+## Tasks
+
+- [ ] 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+# GitHub Copilot Instructions
+All coding standards and architecture decisions for this project are defined in [CLAUDE.md](../.claude/CLAUDE.md) and linked files inside of it. 
+Please strictly follow the rules in that file for all suggestions.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+<!-- 1-3 sentences: what changed and why. -->
+
+## Linked issue
+<!-- Optional. `Closes #N` if this PR fully resolves the issue. `Part of #N` if more PRs will follow. Cross-repo: `Closes Org/Repo#N`. Delete this section for standalone PRs. -->
+Closes # or Part of #
+
+## Test plan
+<!-- How this was / will be verified. Include pre-merge and post-merge checks (e.g. smoke test in target env, dashboard check) when applicable. -->
+- [ ]
+
+## PR Checklist
+- [ ] Branch rebased on latest `origin/main` with commits squashed
+- [ ] Issue, if exists, is linked
+- [ ] Pre-merge Test plan items checked off
+- [ ] All reviewer comments resolved
+

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,67 @@
+# Project Conventions
+
+This document captures one-shot, irreversible-in-practice naming
+decisions that the rest of the codebase, distribution, and downstream
+consumers depend on. Once a public artifact ships under one of these
+names — a tagged Go module, a published container image, a Helm chart
+release, a CRD installed in a user's cluster — renaming it breaks every
+consumer. Treat the values below as immutable; new conventions get
+added, existing ones do not get edited.
+
+## Foundational namespaces
+
+| Concern               | Value                                          |
+|-----------------------|------------------------------------------------|
+| Go module path        | `github.com/northwatchlabs/northwatch`         |
+| CRD API group         | `northwatch.dev/v1alpha1`                      |
+| Container registry    | `ghcr.io/northwatchlabs/northwatch`            |
+| Helm chart OCI path   | `oci://ghcr.io/northwatchlabs/charts/northwatch` |
+
+### Go module path
+
+`github.com/northwatchlabs/northwatch` — set in `go.mod` and reflected
+in every internal import path. The module path is part of every
+`import` statement in every consumer; renaming it breaks `go get` and
+every downstream import.
+
+### CRD API group
+
+`northwatch.dev/v1alpha1` — locked now, applied in v0.3 (Phase 3) when
+CRDs land. The MVP (v0.1.0) reads YAML config; CRDs are deferred but
+the API group is fixed here so first-shipped CRDs match the eventual
+GA group.
+
+The owned domain is `northwatch.dev`. Do not use `northwatch.io`,
+`northwatchlabs.dev`, or any variant — once a CRD installs in a user's
+cluster the group is part of every `apiVersion` field in every stored
+object, and a rename requires a conversion webhook plus migration.
+
+### Container registry
+
+`ghcr.io/northwatchlabs/northwatch` — the single image distributed by
+this project. The Dockerfile and the GitHub Actions publish workflow
+both target this path. Tags follow the release tag (`v0.1.0`, etc.)
+plus `latest` on the most recent stable release.
+
+### Helm chart OCI path
+
+`oci://ghcr.io/northwatchlabs/charts/northwatch` — published as an OCI
+artifact under the same org's GHCR namespace. Users install with:
+
+```sh
+helm install northwatch oci://ghcr.io/northwatchlabs/charts/northwatch --version <x.y.z>
+```
+
+The chart name (`northwatch`) and the OCI repository path are part of
+every `helm install` / `helm upgrade` invocation; renaming either
+forces every consumer to re-target.
+
+## Adding a new convention
+
+If a new naming decision has the same property — once it's public,
+renaming breaks consumers — add it here in the same PR that introduces
+it. Examples that would qualify: a second container image, a metrics
+namespace prefix exposed to Prometheus, a public HTTP API path prefix.
+
+Conventions that are easy to change later (internal package layout,
+unexported types, log field names) do not belong here.


### PR DESCRIPTION
## Summary

- Add `docs/conventions.md` locking the four foundational namespace decisions (Go module path, CRD API group, container registry, Helm OCI path) ratified in the v0.1.0 MVP plan. Future PRs (#11, #13, #14) reference this single source of truth.
- Bootstrap `.github/` with issue templates (Task / Bug / Feature / Epic / Spike), a PR template, CODEOWNERS, and a Copilot pointer to CLAUDE.md. Reserves `workflows/` for the build/release pipeline.

## Test plan

- [x] `docs/conventions.md` renders correctly on GitHub
- [x] All four namespace values match issue #8's body verbatim
- [x] Issue templates appear in the "New issue" picker after merge
- [x] PR template populates the body on next PR
- [x] CODEOWNERS auto-requests review from @demisx on next PR

Closes #8