### PR TITLE
Switch tool-version management to mise

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,0 @@
-golang 1.24.4
-golangci-lint 2.12.2

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 golang 1.24.4
+golangci-lint 2.12.2

--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ that downstream tooling depends on.
 
 ## Develop
 
-Tool versions are pinned in [`.tool-versions`](./.tool-versions) and
-managed with [mise](https://mise.jdx.dev/) (asdf-compatible). Install
-once, then trust the project on first `cd`:
+Tool versions are pinned in [`mise.toml`](./mise.toml) and managed
+with [mise](https://mise.jdx.dev/). Install once, then trust and
+install the project's tools:
 
 ```sh
-brew install mise                            # or see https://mise.jdx.dev/installing-mise.html
+brew install mise                                # or see https://mise.jdx.dev/installing-mise.html
 echo 'eval "$(mise activate zsh)"' >> ~/.zshrc   # bash/fish: see mise docs
-mise trust && mise install                   # installs go, golangci-lint
+mise trust && mise install                       # installs go, golangci-lint, tailwindcss
 ```
 
 Then:
@@ -50,11 +50,9 @@ make build    # compile cmd/northwatch
 make test     # run unit tests
 make vet      # go vet
 make lint     # golangci-lint
+make css      # compile Tailwind CSS
 make run      # build and run
 ```
-
-The existing `.tool-versions` file is also read by asdf if you prefer
-to stick with that.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -33,13 +33,28 @@ that downstream tooling depends on.
 
 ## Develop
 
+Tool versions are pinned in [`.tool-versions`](./.tool-versions) and
+managed with [mise](https://mise.jdx.dev/) (asdf-compatible). Install
+once, then trust the project on first `cd`:
+
+```sh
+brew install mise                            # or see https://mise.jdx.dev/installing-mise.html
+echo 'eval "$(mise activate zsh)"' >> ~/.zshrc   # bash/fish: see mise docs
+mise trust && mise install                   # installs go, golangci-lint
+```
+
+Then:
+
 ```sh
 make build    # compile cmd/northwatch
 make test     # run unit tests
 make vet      # go vet
-make lint     # golangci-lint (must be installed)
+make lint     # golangci-lint
 make run      # build and run
 ```
+
+The existing `.tool-versions` file is also read by asdf if you prefer
+to stick with that.
 
 ## License
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,4 @@
 [tools]
 go = "1.24.4"
 golangci-lint = "2.12.2"
-tailwindcss = "4.3.0"
+"aqua:tailwindlabs/tailwindcss" = "4.3.0"

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,4 @@
+[tools]
+go = "1.24.4"
+golangci-lint = "2.12.2"
+tailwindcss = "4.3.0"


### PR DESCRIPTION
## Summary

- Replaces `.tool-versions` with `mise.toml`. The project standardises on [mise](https://mise.jdx.dev/) — no asdf dual-support.
- Pins `go 1.24.4`, `golangci-lint 2.12.2` (matches the v2 schema in `.golangci.yml`), and `tailwindcss 4.3.0` (matches the v4 `@import "tailwindcss"` / `@source` syntax in `web/input.css`).
- Updates the README with mise install/activation steps and adds `make css` to the standard dev loop.

## Test plan

- [x] `brew install mise && mise trust && mise install` installs `go`, `golangci-lint`, and `tailwindcss` at the pinned versions
- [x] `make build`, `make lint`, and `make css` all run successfully after `mise install`
- [x] `mise current` inside the repo shows the three pinned tools