### PR TITLE
Bump Go toolchain to 1.26.3

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,4 @@
 [tools]
-go = "1.24.4"
+go = "1.26.3"
 golangci-lint = "2.12.2"
 "aqua:tailwindlabs/tailwindcss" = "4.3.0"


### PR DESCRIPTION
## Summary
- Mise was pinning Go at 1.24.4; 1.26.3 is the current stable release.
- `golangci-lint` (2.12.2) and `tailwindcss` (4.3.0) are already on the latest stable versions — no change.

## Test plan
- [x] `mise install` pulls Go 1.26.3
- [x] `go build ./...` succeeds
- [x] `go test ./...` passes across all packages
- [x] `golangci-lint run ./...` reports 0 issues