### PR TITLE
Watch Deployments and reconcile component status

### DIFF
--- a/cmd/northwatch/main.go
+++ b/cmd/northwatch/main.go
@@ -108,7 +108,8 @@ func serveCmd(args []string) int {
 		return 1
 	}
 
-	if code := runConfigSync(ctx, st, *configPath, *allowDeactivate, logger); code != 0 {
+	cfg, code := runConfigSync(ctx, st, *configPath, *allowDeactivate, logger)
+	if code != 0 {
 		return code
 	}
 
@@ -117,7 +118,6 @@ func serveCmd(args []string) int {
 		logger.Error("kubernetes client init failed", "err", err)
 		return 1
 	}
-	_ = kc // Consumed by watchers (#6+); placeholder until then.
 
 	h, err := server.New(logger, st)
 	if err != nil {
@@ -131,11 +131,20 @@ func serveCmd(args []string) int {
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 
-	errCh := make(chan error, 1)
+	// errCh is sized for every long-lived goroutine that can return
+	// an error during steady-state: the HTTP server, and optionally
+	// the Deployment watcher when --no-cluster is not set.
+	errCh := make(chan error, 2)
 	go func() {
 		logger.Info("listening", "addr", srv.Addr, "db", *dbPath)
 		errCh <- srv.ListenAndServe()
 	}()
+	if kc != nil {
+		depWatcher := watcher.NewDeploymentWatcher(kc.Clientset, st, cfg.Components, logger)
+		go func() {
+			errCh <- depWatcher.Start(ctx)
+		}()
+	}
 
 	select {
 	case err := <-errCh:
@@ -210,20 +219,22 @@ func envOrBool(key string, def bool) bool {
 }
 
 // runConfigSync loads configPath, translates Specs into ComponentSpecs,
-// and calls SyncComponents. Returns 0 on success or a non-zero exit
-// code on any failure (the matching error is already logged). Pulled
-// out of serveCmd so it's testable without starting the HTTP server.
+// and calls SyncComponents. Returns the loaded config (so callers can
+// hand it to downstream consumers like the K8s watcher) and an exit
+// code: 0 on success, non-zero on any failure (the matching error is
+// already logged). On non-zero, the returned config is nil. Pulled out
+// of serveCmd so it's testable without starting the HTTP server.
 func runConfigSync(
 	ctx context.Context,
 	st store.Store,
 	configPath string,
 	allowDeactivate bool,
 	logger *slog.Logger,
-) int {
+) (*config.File, int) {
 	cfg, err := config.Load(configPath)
 	if err != nil {
 		logger.Error("config load failed", "err", err, "path", configPath)
-		return 1
+		return nil, 1
 	}
 
 	specs := make([]store.ComponentSpec, 0, len(cfg.Components))
@@ -249,18 +260,18 @@ func runConfigSync(
 			"config", configPath,
 			"hint", "verify the config is correct; re-run with --allow-deactivate to confirm",
 		)
-		return 1
+		return nil, 1
 	}
 	if err != nil {
 		logger.Error("sync components failed", "err", err)
-		return 1
+		return nil, 1
 	}
 	logger.Info("components synced",
 		"active", len(specs),
 		"deactivated", deactivated,
 		"config", configPath,
 	)
-	return 0
+	return cfg, 0
 }
 
 // runClusterInit constructs the shared watcher.Client unless

--- a/cmd/northwatch/main_test.go
+++ b/cmd/northwatch/main_test.go
@@ -88,12 +88,12 @@ func TestRunConfigSync_NoDeactivationsNoFlagNeeded(t *testing.T) {
 	cfgPath := writeConfig(t, cfgAB)
 
 	// Initial run seeds both. No deactivations.
-	code := runConfigSync(ctx, st, cfgPath, false, testLogger())
+	_, code := runConfigSync(ctx, st, cfgPath, false, testLogger())
 	if code != 0 {
 		t.Errorf("code = %d, want 0", code)
 	}
 	// Second run with same config — still no deactivations, no flag needed.
-	code = runConfigSync(ctx, st, cfgPath, false, testLogger())
+	_, code = runConfigSync(ctx, st, cfgPath, false, testLogger())
 	if code != 0 {
 		t.Errorf("second code = %d, want 0", code)
 	}
@@ -104,12 +104,12 @@ func TestRunConfigSync_RefusesDeactivationWithoutFlag(t *testing.T) {
 	ctx := context.Background()
 
 	// Seed both via cfgAB.
-	if code := runConfigSync(ctx, st, writeConfig(t, cfgAB), false, testLogger()); code != 0 {
+	if _, code := runConfigSync(ctx, st, writeConfig(t, cfgAB), false, testLogger()); code != 0 {
 		t.Fatalf("seed: code = %d", code)
 	}
 
 	// Now sync with cfgAOnly (b absent) and no flag — must refuse.
-	code := runConfigSync(ctx, st, writeConfig(t, cfgAOnly), false, testLogger())
+	_, code := runConfigSync(ctx, st, writeConfig(t, cfgAOnly), false, testLogger())
 	if code != 1 {
 		t.Errorf("code = %d, want 1", code)
 	}
@@ -128,11 +128,11 @@ func TestRunConfigSync_AllowsDeactivationWithFlag(t *testing.T) {
 	st := testStoreWithMigrate(t)
 	ctx := context.Background()
 
-	if code := runConfigSync(ctx, st, writeConfig(t, cfgAB), false, testLogger()); code != 0 {
+	if _, code := runConfigSync(ctx, st, writeConfig(t, cfgAB), false, testLogger()); code != 0 {
 		t.Fatalf("seed: code = %d", code)
 	}
 
-	code := runConfigSync(ctx, st, writeConfig(t, cfgAOnly), true, testLogger())
+	_, code := runConfigSync(ctx, st, writeConfig(t, cfgAOnly), true, testLogger())
 	if code != 0 {
 		t.Errorf("code = %d, want 0", code)
 	}
@@ -148,7 +148,7 @@ func TestRunConfigSync_AllowsDeactivationWithFlag(t *testing.T) {
 
 func TestRunConfigSync_MissingConfig(t *testing.T) {
 	st := testStoreWithMigrate(t)
-	code := runConfigSync(context.Background(), st, "/does/not/exist.yaml", false, testLogger())
+	_, code := runConfigSync(context.Background(), st, "/does/not/exist.yaml", false, testLogger())
 	if code != 1 {
 		t.Errorf("code = %d, want 1", code)
 	}
@@ -202,7 +202,7 @@ func TestRunConfigSync_DefaultsDisplayNameToName(t *testing.T) {
 	st := testStoreWithMigrate(t)
 	ctx := context.Background()
 
-	code := runConfigSync(ctx, st, writeConfig(t, cfgNoDN), false, testLogger())
+	_, code := runConfigSync(ctx, st, writeConfig(t, cfgNoDN), false, testLogger())
 	if code != 0 {
 		t.Fatalf("code = %d, want 0", code)
 	}

--- a/examples/basic/sample-deployment.yaml
+++ b/examples/basic/sample-deployment.yaml
@@ -1,0 +1,40 @@
+# Sample workload for the killer-demo flow.
+#
+# Pairs with northwatch.yaml in this directory: the watched component
+# "Deployment/default/api-gateway" matches this Deployment. Apply this
+# to any cluster, then run:
+#
+#   ./northwatch serve --config examples/basic/northwatch.yaml
+#
+# and the status page should show "API Gateway" as operational. Scale
+# to zero with `kubectl scale deploy/api-gateway --replicas=0` to
+# watch the component flip to "down".
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-gateway
+  namespace: default
+  labels:
+    app: api-gateway
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: api-gateway
+  template:
+    metadata:
+      labels:
+        app: api-gateway
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.27-alpine
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	gopkg.in/yaml.v3 v3.0.1
+	k8s.io/api v0.35.5
 	k8s.io/apimachinery v0.35.5
 	k8s.io/client-go v0.35.5
 	modernc.org/sqlite v1.50.1
@@ -21,6 +22,7 @@ require (
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
+	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -30,6 +32,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
@@ -44,7 +47,6 @@ require (
 	google.golang.org/protobuf v1.36.8 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	k8s.io/api v0.35.5 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.yaml.in/yaml/v2 v2.4.3 h1:6gvOSjQoTB3vt1l+CU+tSyi/HOjfOjRLJ4YwYZGwRO0=
 go.yaml.in/yaml/v2 v2.4.3/go.mod h1:zSxWcmIDjOzPXpjlTTbAsKokqkDNAVtZO0WOMiT90s8=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=

--- a/internal/watcher/deployment.go
+++ b/internal/watcher/deployment.go
@@ -1,0 +1,217 @@
+package watcher
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/northwatchlabs/northwatch/internal/component"
+	"github.com/northwatchlabs/northwatch/internal/config"
+	"github.com/northwatchlabs/northwatch/internal/store"
+)
+
+// DeploymentWatcher watches apps/v1.Deployment events for the
+// configured set of components and reconciles their status into the
+// store. Only Deployments whose (namespace, name) appears in the
+// configured set produce store writes; all other Deployments in the
+// cluster are ignored.
+//
+// Status mapping is replica-count only in v0.1; #19 will harden it
+// with Progressing=True + debounce. Rules are evaluated top-to-bottom,
+// so scale-to-zero (desired==0, ready==0) resolves to down rather
+// than operational:
+//   - readyReplicas == 0                         → down
+//   - readyReplicas < spec.replicas              → degraded
+//   - readyReplicas >= spec.replicas             → operational
+//
+// In-cluster RBAC: the watcher needs get, list, watch on
+// apps/v1/deployments. The Helm chart (#24) will ship the appropriate
+// ClusterRole and binding.
+type DeploymentWatcher struct {
+	client  kubernetes.Interface
+	store   store.Store
+	watched map[types.NamespacedName]config.Spec
+	logger  *slog.Logger
+
+	mu       sync.Mutex
+	lastSeen map[types.NamespacedName]component.Status
+
+	syncedCh   chan struct{}
+	syncedOnce sync.Once
+}
+
+// NewDeploymentWatcher constructs the watcher from a clientset, a
+// store, and the configured component specs. It filters specs to
+// Kind == "Deployment" and builds the lookup table. An empty or nil
+// specs slice is valid — the watcher runs but writes nothing because
+// every event is filtered out. A nil logger falls back to
+// slog.Default().
+func NewDeploymentWatcher(
+	client kubernetes.Interface,
+	st store.Store,
+	specs []config.Spec,
+	logger *slog.Logger,
+) *DeploymentWatcher {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	watched := make(map[types.NamespacedName]config.Spec)
+	for _, s := range specs {
+		if s.Kind != "Deployment" {
+			continue
+		}
+		key := types.NamespacedName{Namespace: s.Namespace, Name: s.Name}
+		watched[key] = s
+	}
+	return &DeploymentWatcher{
+		client:   client,
+		store:    st,
+		watched:  watched,
+		logger:   logger.With("watcher", "deployment"),
+		lastSeen: make(map[types.NamespacedName]component.Status),
+		syncedCh: make(chan struct{}),
+	}
+}
+
+// Synced returns a channel that is closed once the watcher's informer
+// cache has finished its initial list/watch sync. Useful for tests
+// (avoids a race between Start and the first test mutation) and for
+// startup ordering (callers can log "ready" only after sync).
+func (w *DeploymentWatcher) Synced() <-chan struct{} {
+	return w.syncedCh
+}
+
+// Start runs the informer until ctx is cancelled. It blocks; the
+// caller is expected to launch it in its own goroutine. Returns nil
+// on clean shutdown via ctx.Done(); returns a non-nil error if the
+// informer cache fails to sync. Resync period is 0 (event-driven
+// only) — #19 may revisit this when adding debounce.
+func (w *DeploymentWatcher) Start(ctx context.Context) error {
+	factory := informers.NewSharedInformerFactory(w.client, 0)
+	informer := factory.Apps().V1().Deployments().Informer()
+
+	if _, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			d, ok := obj.(*appsv1.Deployment)
+			if !ok {
+				return
+			}
+			w.handle(ctx, d)
+		},
+		UpdateFunc: func(_, newObj interface{}) {
+			d, ok := newObj.(*appsv1.Deployment)
+			if !ok {
+				return
+			}
+			w.handle(ctx, d)
+		},
+		DeleteFunc: func(_ interface{}) {
+			// Deletion leaves the last status in place (acceptance
+			// criterion: "delete leaves status as down, no crash").
+			// We don't clear lastSeen so a same-status recreate stays
+			// a no-op; we don't upsert because there's no new state
+			// to record.
+		},
+	}); err != nil {
+		return fmt.Errorf("watcher: add event handler: %w", err)
+	}
+
+	factory.Start(ctx.Done())
+	if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
+		// WaitForCacheSync returns false when stopCh is closed before
+		// HasSynced flips true. Treat that as a clean shutdown — the
+		// informer poll period (100ms) is racy with rapid cancel
+		// even when events were already flowing.
+		if ctx.Err() != nil {
+			return nil
+		}
+		return errors.New("watcher: deployment cache sync failed")
+	}
+	w.syncedOnce.Do(func() { close(w.syncedCh) })
+	w.logger.Info("synced", "watched", len(w.watched))
+
+	<-ctx.Done()
+	return nil
+}
+
+func (w *DeploymentWatcher) handle(ctx context.Context, d *appsv1.Deployment) {
+	key := types.NamespacedName{Namespace: d.Namespace, Name: d.Name}
+	spec, ok := w.watched[key]
+	if !ok {
+		return
+	}
+
+	status := computeDeploymentStatus(d)
+
+	w.mu.Lock()
+	prev, seen := w.lastSeen[key]
+	if seen && prev == status {
+		w.mu.Unlock()
+		return
+	}
+	w.lastSeen[key] = status
+	w.mu.Unlock()
+
+	c := component.Component{
+		Kind:        "Deployment",
+		Namespace:   spec.Namespace,
+		Name:        spec.Name,
+		DisplayName: displayNameOrName(spec),
+		Status:      status,
+	}
+	if err := w.store.UpsertComponent(ctx, c); err != nil {
+		w.logger.Error("upsert failed",
+			"err", err,
+			"id", c.ID(),
+			"status", string(status),
+		)
+		// Roll back lastSeen so the next event for this key retries.
+		w.mu.Lock()
+		if seen {
+			w.lastSeen[key] = prev
+		} else {
+			delete(w.lastSeen, key)
+		}
+		w.mu.Unlock()
+		return
+	}
+	w.logger.Info("reconciled",
+		"id", c.ID(),
+		"status", string(status),
+	)
+}
+
+// computeDeploymentStatus maps Deployment replica counts to a
+// component.Status. spec.replicas defaults to 1 when unset (k8s
+// default). Used as a package-private helper rather than a method so
+// it's directly testable without constructing a DeploymentWatcher.
+func computeDeploymentStatus(d *appsv1.Deployment) component.Status {
+	desired := int32(1)
+	if d.Spec.Replicas != nil {
+		desired = *d.Spec.Replicas
+	}
+	ready := d.Status.ReadyReplicas
+	switch {
+	case ready == 0:
+		return component.StatusDown
+	case ready < desired:
+		return component.StatusDegraded
+	default:
+		return component.StatusOperational
+	}
+}
+
+func displayNameOrName(s config.Spec) string {
+	if s.DisplayName != "" {
+		return s.DisplayName
+	}
+	return s.Name
+}

--- a/internal/watcher/deployment_test.go
+++ b/internal/watcher/deployment_test.go
@@ -1,0 +1,371 @@
+package watcher
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/northwatchlabs/northwatch/internal/component"
+	"github.com/northwatchlabs/northwatch/internal/config"
+	"github.com/northwatchlabs/northwatch/internal/store"
+)
+
+// settleWindow caps how long the tests wait when asserting the
+// *absence* of an event. Long enough that a delayed informer dispatch
+// would land; short enough that the suite stays fast.
+const settleWindow = 150 * time.Millisecond
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// recordStore is a store.Store double that records every
+// UpsertComponent call and signals via a channel so tests can wait
+// for events without polling.
+type recordStore struct {
+	mu       sync.Mutex
+	calls    []component.Component
+	upsertCh chan struct{}
+}
+
+func newRecordStore() *recordStore {
+	return &recordStore{upsertCh: make(chan struct{}, 64)}
+}
+
+func (s *recordStore) Close() error                  { return nil }
+func (s *recordStore) Migrate(context.Context) error { return nil }
+func (s *recordStore) ListComponents(context.Context) ([]component.Component, error) {
+	return nil, nil
+}
+func (s *recordStore) GetComponent(context.Context, string) (component.Component, error) {
+	return component.Component{}, store.ErrNotFound
+}
+func (s *recordStore) UpsertComponent(_ context.Context, c component.Component) error {
+	s.mu.Lock()
+	s.calls = append(s.calls, c)
+	s.mu.Unlock()
+	select {
+	case s.upsertCh <- struct{}{}:
+	default:
+	}
+	return nil
+}
+func (s *recordStore) SyncComponents(context.Context, []store.ComponentSpec, bool) (int, error) {
+	return 0, nil
+}
+
+func (s *recordStore) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.calls)
+}
+
+func (s *recordStore) snapshot() []component.Component {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]component.Component, len(s.calls))
+	copy(out, s.calls)
+	return out
+}
+
+// waitForCalls blocks until count() >= n, or fails the test on a
+// 2-second deadline.
+func (s *recordStore) waitForCalls(t *testing.T, n int) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	for {
+		if s.count() >= n {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timeout waiting for %d upserts; got %d", n, s.count())
+		case <-s.upsertCh:
+		}
+	}
+}
+
+// assertCountStable asserts that the call count remains == expected
+// for the full settleWindow. Use after waitForCalls(n) to prove
+// "exactly n, not n+1" within a bounded wait.
+func (s *recordStore) assertCountStable(t *testing.T, expected int) {
+	t.Helper()
+	deadline := time.After(settleWindow)
+	for {
+		select {
+		case <-deadline:
+			if got := s.count(); got != expected {
+				t.Fatalf("count = %d after settle, want %d", got, expected)
+			}
+			return
+		case <-s.upsertCh:
+			if got := s.count(); got > expected {
+				t.Fatalf("unexpected upsert: count = %d, want %d", got, expected)
+			}
+		}
+	}
+}
+
+func newDeployment(ns, name string, desired, ready int32) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec:       appsv1.DeploymentSpec{Replicas: &desired},
+		Status: appsv1.DeploymentStatus{
+			Replicas:      desired,
+			ReadyReplicas: ready,
+		},
+	}
+}
+
+// updateDeploymentStatus fetches the named Deployment, replaces its
+// status, and Updates. This pattern emits a clean Modified event
+// through the fake clientset's watch channel — constructing fresh
+// objects without ResourceVersion can race with the informer's
+// DeltaFIFO under -race.
+func updateDeploymentStatus(t *testing.T, cs *fake.Clientset, ns, name string, desired, ready int32) {
+	t.Helper()
+	ctx := context.Background()
+	cur, err := cs.AppsV1().Deployments(ns).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get %s/%s: %v", ns, name, err)
+	}
+	cur.Spec.Replicas = &desired
+	cur.Status.Replicas = desired
+	cur.Status.ReadyReplicas = ready
+	if _, err := cs.AppsV1().Deployments(ns).Update(ctx, cur, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("update %s/%s: %v", ns, name, err)
+	}
+}
+
+// startWatcher launches a watcher goroutine, blocks until its
+// informer cache is synced, and returns a cleanup func the test
+// should defer. Errors from Start are surfaced through a channel
+// (never via t.Errorf from the goroutine) so timeouts can join the
+// goroutine before failing the test — otherwise a late t.Errorf
+// would log after the test has finished.
+func startWatcher(t *testing.T, cs *fake.Clientset, rs store.Store, specs []config.Spec) func() {
+	t.Helper()
+	w := NewDeploymentWatcher(cs, rs, specs, quietLogger())
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- w.Start(ctx) }()
+
+	select {
+	case <-w.Synced():
+	case <-time.After(2 * time.Second):
+		cancel()
+		select {
+		case err := <-errCh:
+			t.Fatalf("watcher did not sync within 2s (Start returned %v)", err)
+		case <-time.After(2 * time.Second):
+			t.Fatal("watcher did not sync within 2s and did not exit after cancel")
+		}
+	}
+
+	return func() {
+		cancel()
+		select {
+		case err := <-errCh:
+			if err != nil {
+				t.Errorf("Start returned error: %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("watcher did not stop within 2s of cancel")
+		}
+	}
+}
+
+func TestDeploymentWatcher_ReplicaTransitions(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	rs := newRecordStore()
+	specs := []config.Spec{{
+		Kind: "Deployment", Namespace: "default", Name: "api", DisplayName: "API",
+	}}
+	stop := startWatcher(t, cs, rs, specs)
+	defer stop()
+
+	ctx := context.Background()
+	// operational: 3/3
+	if _, err := cs.AppsV1().Deployments("default").
+		Create(ctx, newDeployment("default", "api", 3, 3), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	rs.waitForCalls(t, 1)
+	if got := rs.snapshot()[0].Status; got != component.StatusOperational {
+		t.Errorf("[0] status = %q, want %q", got, component.StatusOperational)
+	}
+
+	// degraded: 3/2
+	updateDeploymentStatus(t, cs, "default", "api", 3, 2)
+	rs.waitForCalls(t, 2)
+	if got := rs.snapshot()[1].Status; got != component.StatusDegraded {
+		t.Errorf("[1] status = %q, want %q", got, component.StatusDegraded)
+	}
+
+	// down: 3/0
+	updateDeploymentStatus(t, cs, "default", "api", 3, 0)
+	rs.waitForCalls(t, 3)
+	if got := rs.snapshot()[2].Status; got != component.StatusDown {
+		t.Errorf("[2] status = %q, want %q", got, component.StatusDown)
+	}
+
+	// operational again: 3/3
+	updateDeploymentStatus(t, cs, "default", "api", 3, 3)
+	rs.waitForCalls(t, 4)
+	if got := rs.snapshot()[3].Status; got != component.StatusOperational {
+		t.Errorf("[3] status = %q, want %q", got, component.StatusOperational)
+	}
+}
+
+func TestDeploymentWatcher_UnwatchedIgnored(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	rs := newRecordStore()
+	specs := []config.Spec{{
+		Kind: "Deployment", Namespace: "default", Name: "watched", DisplayName: "Watched",
+	}}
+	stop := startWatcher(t, cs, rs, specs)
+	defer stop()
+
+	ctx := context.Background()
+	// Different name, same namespace — must be ignored.
+	if _, err := cs.AppsV1().Deployments("default").
+		Create(ctx, newDeployment("default", "other", 1, 1), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create other: %v", err)
+	}
+	// Same name, different namespace — must be ignored.
+	if _, err := cs.AppsV1().Deployments("staging").
+		Create(ctx, newDeployment("staging", "watched", 1, 1), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create staging: %v", err)
+	}
+	// Watched: should produce exactly one upsert.
+	if _, err := cs.AppsV1().Deployments("default").
+		Create(ctx, newDeployment("default", "watched", 1, 1), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create watched: %v", err)
+	}
+
+	rs.waitForCalls(t, 1)
+	rs.assertCountStable(t, 1)
+	got := rs.snapshot()[0]
+	if got.Name != "watched" || got.Namespace != "default" {
+		t.Errorf("unexpected component upserted: %+v", got)
+	}
+}
+
+func TestDeploymentWatcher_StatusUnchangedNoOp(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	rs := newRecordStore()
+	specs := []config.Spec{{
+		Kind: "Deployment", Namespace: "default", Name: "api", DisplayName: "API",
+	}}
+	stop := startWatcher(t, cs, rs, specs)
+	defer stop()
+
+	ctx := context.Background()
+	if _, err := cs.AppsV1().Deployments("default").
+		Create(ctx, newDeployment("default", "api", 3, 3), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	rs.waitForCalls(t, 1)
+
+	// Identical status update — must NOT trigger a second upsert.
+	updateDeploymentStatus(t, cs, "default", "api", 3, 3)
+	rs.assertCountStable(t, 1)
+
+	// Now a real status change — should trigger an upsert.
+	updateDeploymentStatus(t, cs, "default", "api", 3, 0)
+	rs.waitForCalls(t, 2)
+}
+
+func TestDeploymentWatcher_DeleteLeavesStatus(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	rs := newRecordStore()
+	specs := []config.Spec{{
+		Kind: "Deployment", Namespace: "default", Name: "api", DisplayName: "API",
+	}}
+	stop := startWatcher(t, cs, rs, specs)
+	defer stop()
+
+	ctx := context.Background()
+	if _, err := cs.AppsV1().Deployments("default").
+		Create(ctx, newDeployment("default", "api", 3, 0), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	rs.waitForCalls(t, 1)
+	if got := rs.snapshot()[0].Status; got != component.StatusDown {
+		t.Fatalf("initial status = %q, want %q", got, component.StatusDown)
+	}
+
+	if err := cs.AppsV1().Deployments("default").
+		Delete(ctx, "api", metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	// Deletion must not produce any further upsert.
+	rs.assertCountStable(t, 1)
+	// The recorded last status remains "down" — acceptance criterion.
+	if got := rs.snapshot()[0].Status; got != component.StatusDown {
+		t.Errorf("recorded status after delete = %q, want %q", got, component.StatusDown)
+	}
+}
+
+func TestDeploymentWatcher_CrossKindIsolation(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	rs := newRecordStore()
+	// Spec's (ns, name) matches the Deployment below, but Kind is
+	// HelmRelease — the Deployment must NOT match the watched set.
+	specs := []config.Spec{{
+		Kind: "HelmRelease", Namespace: "default", Name: "api",
+	}}
+	stop := startWatcher(t, cs, rs, specs)
+	defer stop()
+
+	ctx := context.Background()
+	if _, err := cs.AppsV1().Deployments("default").
+		Create(ctx, newDeployment("default", "api", 1, 1), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	rs.assertCountStable(t, 0)
+}
+
+func TestDeploymentWatcher_DisplayNamePropagation(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	rs := newRecordStore()
+	specs := []config.Spec{{
+		Kind:        "Deployment",
+		Namespace:   "default",
+		Name:        "api",
+		DisplayName: "API Gateway",
+	}}
+	stop := startWatcher(t, cs, rs, specs)
+	defer stop()
+
+	ctx := context.Background()
+	if _, err := cs.AppsV1().Deployments("default").
+		Create(ctx, newDeployment("default", "api", 1, 1), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	rs.waitForCalls(t, 1)
+	got := rs.snapshot()[0]
+	if got.DisplayName != "API Gateway" {
+		t.Errorf("DisplayName = %q, want %q", got.DisplayName, "API Gateway")
+	}
+	if got.Kind != "Deployment" {
+		t.Errorf("Kind = %q, want %q", got.Kind, "Deployment")
+	}
+}
+
+func TestComputeDeploymentStatus_NilReplicasDefaultsToOne(t *testing.T) {
+	d := &appsv1.Deployment{
+		Spec:   appsv1.DeploymentSpec{Replicas: nil},
+		Status: appsv1.DeploymentStatus{ReadyReplicas: 1},
+	}
+	if got := computeDeploymentStatus(d); got != component.StatusOperational {
+		t.Errorf("got %q, want %q (nil replicas should default to 1)", got, component.StatusOperational)
+	}
+}


### PR DESCRIPTION
## Summary

- First Kubernetes reconciler: an `apps/v1.Deployment` SharedInformer that filters events against the configured watched-component set and upserts component status into the store. Sets the pattern that #17 (HelmRelease) and #18 (ArgoCD Application) will copy; #19 will harden the mapping with `Progressing=True` + debounce.
- Status mapping is replica-only for v0.1: `ready == 0 → down`, `0 < ready < desired → degraded`, otherwise `operational`. Identical no-op updates are suppressed via an in-memory `lastSeen` cache so `updated_at` stays honest as "last status change". Deletion leaves the last status in place.
- Watcher runs alongside the HTTP server on a shared signal context; either goroutine exiting trips graceful shutdown. Skipped under `--no-cluster`.
- Includes `examples/basic/sample-deployment.yaml` matching the `api-gateway` entry in the existing `northwatch.yaml`, so the "apply / scale / status flips" demo is one `kubectl apply` away from end-to-end visible.

Closes #16

## Test plan

- [x] `go test -race ./...` passes cleanly (10× iterations on the watcher package)
- [x] `kind create cluster` + apply `examples/basic/sample-deployment.yaml` → status page shows `operational`
- [x] `kubectl scale --replicas=0` → status flips to `down` within seconds
- [x] `kubectl scale --replicas=3` → status returns to `operational` after rollout
- [x] Delete Deployment while `down` → status remains `down`, no panic in server logs
- [x] Unwatched Deployments in the same cluster produce no store writes (unit-tested)
- [x] Cross-kind isolation: a `HelmRelease` spec with the same `(ns, name)` as a Deployment does not match (unit-tested)