### PR TITLE
Spell out mise shell activation for zsh, bash, and fish

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,28 @@ with [mise](https://mise.jdx.dev/). Install once, then trust and
 install the project's tools:
 
 ```sh
-brew install mise                                # or see https://mise.jdx.dev/installing-mise.html
-echo 'eval "$(mise activate zsh)"' >> ~/.zshrc   # bash/fish: see mise docs
-mise trust && mise install                       # installs go, golangci-lint, tailwindcss, kind, kubectl, kubectx, flux
+brew install mise   # or see https://mise.jdx.dev/installing-mise.html
+```
+
+Activate `mise` in your shell so its shims land on `$PATH`. Pick the
+line for your shell and append it to your rc file:
+
+```sh
+# zsh
+echo 'eval "$(mise activate zsh)"' >> ~/.zshrc
+
+# bash
+echo 'eval "$(mise activate bash)"' >> ~/.bashrc
+
+# fish
+echo 'mise activate fish | source' >> ~/.config/fish/config.fish
+```
+
+Open a new shell (or `source` the rc file), then install the
+project's tools:
+
+```sh
+mise trust && mise install   # installs go, golangci-lint, tailwindcss, kind, kubectl, kubectx, flux
 ```
 
 Then:


### PR DESCRIPTION
## Summary

- The Develop section gave only the zsh activation line and pointed bash/fish users at the mise docs — that punt produced a "command not found" failure on fish the first time anyone tries to build the project (hit live during today's dogfooding of the new demo recipe in #40).
- Spell out all three shell activations explicitly, split install / activate / install-tools into three steps so the order reads correctly, and remind the reader to open a new shell after the activation line lands in their rc file.

Standalone PR — doc polish, no linked issue.

## Test plan

- [x] Render the updated README via GitHub's markdown API to confirm fences and code blocks render cleanly
- [x] The fish activation line (`mise activate fish | source`) is the form that resolved the live "Unknown command: ./northwatch" error during dogfooding
- [x] Eyeball the rendered diff on the PR's Files tab — the new three-shell block reads naturally, not like a brittle list