### PR TITLE
Wrap demo heredoc in bash -c for fish compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ controllers and apply a real release:
 flux --context kind-nw-demo install \
     --components=source-controller,helm-controller
 
-kubectl --context kind-nw-demo apply -f - <<'EOF'
+bash -c "kubectl --context kind-nw-demo apply -f - <<'EOF'
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata: { name: podinfo, namespace: default }
@@ -84,6 +84,7 @@ spec:
       version: '6.x'
       sourceRef: { kind: HelmRepository, name: podinfo }
 EOF
+"
 ```
 
 Point a config entry at `HelmRelease/default/podinfo`, restart


### PR DESCRIPTION
## Summary

- The kubectl apply heredoc in the demo recipe (added in #40) works in bash and zsh but fails on paste in fish, which doesn't parse `<<'EOF'` the same way. Confirmed live by you while running through the demo.
- Wrap the entire command in `bash -c "..."` so bash parses the heredoc regardless of the user's interactive shell. Same block now works in fish, bash, and zsh prompts.

Standalone PR — doc polish, no linked issue.

## Test plan

- [x] `bash -c "cat <<'EOF' ... EOF"` emits the YAML body intact (verified locally — exit 0, full body preserved)
- [x] The wrapping form is the one user validated live in fish
- [x] README renders cleanly via GitHub markdown API, fences still balanced