### PR TITLE
Add incidents service, store, and GET /api/incidents handler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/golang-migrate/migrate/v4 v4.19.1
+	github.com/oklog/ulid/v2 v2.1.1
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.35.5
 	k8s.io/apimachinery v0.35.5

--- a/go.sum
+++ b/go.sum
@@ -65,11 +65,14 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
+github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=
+github.com/oklog/ulid/v2 v2.1.1/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
 github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
 github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns=
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=
 github.com/onsi/gomega v1.38.2/go.mod h1:W2MJcYxRGV63b418Ai34Ud0hEdTVXq9NW9+Sx6uXf3k=
+github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/internal/incident/errors.go
+++ b/internal/incident/errors.go
@@ -1,0 +1,22 @@
+package incident
+
+import "errors"
+
+// ErrUnknownComponent is returned by Service.CreateIncident when the
+// component_id does not match any row in the components table.
+// Handlers map this to HTTP 400.
+var ErrUnknownComponent = errors.New("incident: unknown component")
+
+// ErrTitleRequired is returned by Service.CreateIncident when the
+// title is empty after whitespace trimming. Handlers map this to
+// HTTP 400.
+var ErrTitleRequired = errors.New("incident: title required")
+
+// ErrNotFound is the shared "row not found" sentinel for store lookups.
+// The store package re-exports this as store.ErrNotFound so existing
+// callers that check errors.Is(err, store.ErrNotFound) keep working.
+// Living here (in the leaf incident package) breaks what would
+// otherwise be a circular dependency between incident.Service and
+// the store package. The message keeps a namespace prefix so logs
+// remain unambiguous even though several packages re-export it.
+var ErrNotFound = errors.New("incident: not found")

--- a/internal/incident/id.go
+++ b/internal/incident/id.go
@@ -1,0 +1,15 @@
+package incident
+
+import (
+	"crypto/rand"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+)
+
+// NewID returns a fresh ULID string. ULIDs sort lexicographically by
+// generation time, which makes them pleasant in logs and as
+// debug-visible identifiers. The randomness source is crypto/rand.
+func NewID() string {
+	return ulid.MustNew(ulid.Timestamp(time.Now()), rand.Reader).String()
+}

--- a/internal/incident/id_test.go
+++ b/internal/incident/id_test.go
@@ -1,0 +1,18 @@
+package incident_test
+
+import (
+	"testing"
+
+	"github.com/northwatchlabs/northwatch/internal/incident"
+)
+
+func TestNewIDReturnsDistinctULIDs(t *testing.T) {
+	a := incident.NewID()
+	b := incident.NewID()
+	if a == b {
+		t.Fatalf("NewID returned duplicate value: %s", a)
+	}
+	if len(a) != 26 {
+		t.Fatalf("NewID length = %d, want 26 (ULID)", len(a))
+	}
+}

--- a/internal/incident/incident.go
+++ b/internal/incident/incident.go
@@ -1,0 +1,39 @@
+// Package incident defines the Incident domain type, the Status
+// enum used across the service, store, and HTTP layers, and the
+// Service that orchestrates incident creation.
+package incident
+
+import "time"
+
+// Status is the lifecycle state of an incident. Mirrors the
+// SQLite CHECK constraint on incidents.status / incident_updates.status.
+type Status string
+
+const (
+	StatusInvestigating Status = "investigating"
+	StatusIdentified    Status = "identified"
+	StatusMonitoring    Status = "monitoring"
+	StatusResolved      Status = "resolved"
+)
+
+// Incident is one operator-visible event affecting a Component.
+// ResolvedAt is nil while the incident is active.
+type Incident struct {
+	ID          string
+	ComponentID string
+	Title       string
+	Status      Status
+	OpenedAt    time.Time
+	ResolvedAt  *time.Time
+}
+
+// Update is one row in the incident_updates timeline. The service
+// auto-creates the first Update when an Incident is created; v0.2
+// adds POST /incidents/:id/updates to append more.
+type Update struct {
+	ID         string
+	IncidentID string
+	Body       string
+	Status     Status
+	CreatedAt  time.Time
+}

--- a/internal/incident/service.go
+++ b/internal/incident/service.go
@@ -1,0 +1,100 @@
+package incident
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+// Store is the consumer-defined persistence interface for the
+// incident Service. *store.SQLite satisfies it via duck typing.
+// Defining it here (rather than in the store package) avoids the
+// import cycle that would arise from internal/store already
+// importing internal/incident for its method signatures.
+type Store interface {
+	HasActiveComponent(ctx context.Context, id string) (bool, error)
+	CreateIncident(ctx context.Context, inc Incident, firstUpdate Update) error
+	GetActiveIncident(ctx context.Context) (Incident, error)
+	ListIncidents(ctx context.Context, includeResolved bool) ([]Incident, error)
+}
+
+// Service is the use-case layer for incidents. It validates input,
+// generates IDs and timestamps, and orchestrates store calls. The
+// HTTP layer depends on *Service rather than Store directly.
+type Service struct {
+	st     Store
+	logger *slog.Logger
+	now    func() time.Time
+	newID  func() string
+}
+
+// NewService wires a Service against the given store. now and newID
+// default to time.Now and NewID; tests can override them via the
+// SetClockForTest / SetIDForTest helpers.
+func NewService(st Store, logger *slog.Logger) *Service {
+	return &Service{
+		st:     st,
+		logger: logger,
+		now:    func() time.Time { return time.Now().UTC() },
+		newID:  NewID,
+	}
+}
+
+// CreateIncident validates input, generates IDs and timestamps,
+// and persists the incident plus its first incident_updates row.
+// Returns ErrTitleRequired if title is empty after trimming, or
+// ErrUnknownComponent if componentID does not match an ACTIVE
+// component in the components table (missing IDs and soft-
+// deactivated IDs both map to ErrUnknownComponent).
+func (s *Service) CreateIncident(ctx context.Context, componentID, title string) (Incident, error) {
+	title = strings.TrimSpace(title)
+	if title == "" {
+		return Incident{}, ErrTitleRequired
+	}
+	ok, err := s.st.HasActiveComponent(ctx, componentID)
+	if err != nil {
+		return Incident{}, err
+	}
+	if !ok {
+		return Incident{}, ErrUnknownComponent
+	}
+
+	now := s.now()
+	inc := Incident{
+		ID:          s.newID(),
+		ComponentID: componentID,
+		Title:       title,
+		Status:      StatusInvestigating,
+		OpenedAt:    now,
+	}
+	upd := Update{
+		ID:         s.newID(),
+		IncidentID: inc.ID,
+		Body:       title,
+		Status:     StatusInvestigating,
+		CreatedAt:  now,
+	}
+	if err := s.st.CreateIncident(ctx, inc, upd); err != nil {
+		return Incident{}, err
+	}
+	return inc, nil
+}
+
+// GetActiveIncident returns the most recent active incident, or
+// ErrNotFound when none.
+func (s *Service) GetActiveIncident(ctx context.Context) (Incident, error) {
+	return s.st.GetActiveIncident(ctx)
+}
+
+// ListIncidents returns incidents ordered by opened_at DESC. When
+// includeResolved is false, resolved rows are excluded.
+func (s *Service) ListIncidents(ctx context.Context, includeResolved bool) ([]Incident, error) {
+	return s.st.ListIncidents(ctx, includeResolved)
+}
+
+// SetClockForTest overrides the time source. Test-only.
+func (s *Service) SetClockForTest(now func() time.Time) { s.now = now }
+
+// SetIDForTest overrides the ID generator. Test-only.
+func (s *Service) SetIDForTest(newID func() string) { s.newID = newID }

--- a/internal/incident/service_test.go
+++ b/internal/incident/service_test.go
@@ -1,0 +1,133 @@
+package incident_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/northwatchlabs/northwatch/internal/component"
+	"github.com/northwatchlabs/northwatch/internal/incident"
+	"github.com/northwatchlabs/northwatch/internal/store"
+)
+
+// newServiceWithStore builds a Service against a fresh in-memory
+// SQLite, seeded with one component the tests can target.
+func newServiceWithStore(t *testing.T) (*incident.Service, *store.SQLite) {
+	t.Helper()
+	ctx := context.Background()
+	st, err := store.OpenSQLite(ctx, ":memory:")
+	if err != nil {
+		t.Fatalf("OpenSQLite: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	if err := st.UpsertComponent(ctx, component.Component{
+		Kind: "Deployment", Namespace: "default", Name: "web",
+	}); err != nil {
+		t.Fatalf("UpsertComponent: %v", err)
+	}
+	svc := incident.NewService(st, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	return svc, st
+}
+
+func TestCreateIncidentTrimsTitle(t *testing.T) {
+	svc, _ := newServiceWithStore(t)
+	got, err := svc.CreateIncident(context.Background(),
+		"Deployment/default/web", "  Pods down  ")
+	if err != nil {
+		t.Fatalf("CreateIncident: %v", err)
+	}
+	if got.Title != "Pods down" {
+		t.Errorf("Title = %q, want %q", got.Title, "Pods down")
+	}
+}
+
+func TestCreateIncidentEmptyTitle(t *testing.T) {
+	svc, _ := newServiceWithStore(t)
+	_, err := svc.CreateIncident(context.Background(),
+		"Deployment/default/web", "")
+	if !errors.Is(err, incident.ErrTitleRequired) {
+		t.Fatalf("err = %v, want ErrTitleRequired", err)
+	}
+}
+
+func TestCreateIncidentWhitespaceTitle(t *testing.T) {
+	svc, _ := newServiceWithStore(t)
+	_, err := svc.CreateIncident(context.Background(),
+		"Deployment/default/web", "   \t  ")
+	if !errors.Is(err, incident.ErrTitleRequired) {
+		t.Fatalf("err = %v, want ErrTitleRequired", err)
+	}
+}
+
+func TestCreateIncidentUnknownComponent(t *testing.T) {
+	svc, _ := newServiceWithStore(t)
+	_, err := svc.CreateIncident(context.Background(),
+		"Deployment/default/missing", "title")
+	if !errors.Is(err, incident.ErrUnknownComponent) {
+		t.Fatalf("err = %v, want ErrUnknownComponent", err)
+	}
+}
+
+func TestCreateIncidentInactiveComponent(t *testing.T) {
+	svc, st := newServiceWithStore(t)
+	// Soft-deactivate the seeded component.
+	if _, err := st.DB().ExecContext(context.Background(),
+		`UPDATE components SET active = 0 WHERE id = ?`,
+		"Deployment/default/web"); err != nil {
+		t.Fatalf("deactivate: %v", err)
+	}
+	_, err := svc.CreateIncident(context.Background(),
+		"Deployment/default/web", "title")
+	if !errors.Is(err, incident.ErrUnknownComponent) {
+		t.Fatalf("err = %v, want ErrUnknownComponent", err)
+	}
+}
+
+func TestCreateIncidentInitialUpdateMirrorsTitle(t *testing.T) {
+	svc, st := newServiceWithStore(t)
+	got, err := svc.CreateIncident(context.Background(),
+		"Deployment/default/web", "Pods crashlooping")
+	if err != nil {
+		t.Fatalf("CreateIncident: %v", err)
+	}
+	var body string
+	if err := st.DB().QueryRow(
+		`SELECT body FROM incident_updates WHERE incident_id = ?`,
+		got.ID).Scan(&body); err != nil {
+		t.Fatalf("query update: %v", err)
+	}
+	if body != "Pods crashlooping" {
+		t.Errorf("update body = %q, want %q", body, "Pods crashlooping")
+	}
+}
+
+func TestCreateIncidentDeterministicWithInjectedClockAndID(t *testing.T) {
+	svc, _ := newServiceWithStore(t)
+	fixed := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	svc.SetClockForTest(func() time.Time { return fixed })
+	ids := []string{"01HXINC0000000000000000Z1", "01HXUPD0000000000000000Z1"}
+	i := 0
+	svc.SetIDForTest(func() string {
+		out := ids[i]
+		i++
+		return out
+	})
+
+	got, err := svc.CreateIncident(context.Background(),
+		"Deployment/default/web", "stable")
+	if err != nil {
+		t.Fatalf("CreateIncident: %v", err)
+	}
+	if got.ID != ids[0] {
+		t.Errorf("incident ID = %s, want %s", got.ID, ids[0])
+	}
+	if !got.OpenedAt.Equal(fixed) {
+		t.Errorf("OpenedAt = %v, want %v", got.OpenedAt, fixed)
+	}
+}

--- a/internal/server/incidents.go
+++ b/internal/server/incidents.go
@@ -1,0 +1,121 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/northwatchlabs/northwatch/internal/incident"
+)
+
+// apiIncident is the JSON wire shape. Kept separate from
+// incident.Incident so the API can evolve (rename fields, hide
+// internals) without touching the domain type.
+type apiIncident struct {
+	ID          string     `json:"id"`
+	ComponentID string     `json:"component"`
+	Title       string     `json:"title"`
+	Status      string     `json:"status"`
+	OpenedAt    time.Time  `json:"openedAt"`
+	ResolvedAt  *time.Time `json:"resolvedAt,omitempty"`
+}
+
+type createIncidentReq struct {
+	Component string `json:"component"`
+	Title     string `json:"title"`
+}
+
+func toAPIIncident(in incident.Incident) apiIncident {
+	return apiIncident{
+		ID:          in.ID,
+		ComponentID: in.ComponentID,
+		Title:       in.Title,
+		Status:      string(in.Status),
+		OpenedAt:    in.OpenedAt,
+		ResolvedAt:  in.ResolvedAt,
+	}
+}
+
+func toAPIIncidents(in []incident.Incident) []apiIncident {
+	out := make([]apiIncident, 0, len(in))
+	for _, i := range in {
+		out = append(out, toAPIIncident(i))
+	}
+	return out
+}
+
+// apiIncidentsHandler serves GET /api/incidents. Returns active
+// incidents by default; ?include=resolved returns everything.
+func apiIncidentsHandler(svc *incident.Service, logger *slog.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		includeResolved := r.URL.Query().Get("include") == "resolved"
+		incs, err := svc.ListIncidents(r.Context(), includeResolved)
+		if err != nil {
+			logger.Error("api/incidents: ListIncidents failed", "err", err)
+			http.Error(w, "store error", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.Header().Set("Cache-Control", "no-store")
+		if err := json.NewEncoder(w).Encode(toAPIIncidents(incs)); err != nil {
+			logger.Error("api/incidents: encode failed", "err", err)
+		}
+	}
+}
+
+// createIncidentHandler serves POST /incidents. NOT registered in
+// server.New in this PR — issue #21 wires it under bearer-token
+// middleware. Exposed via CreateIncidentHandlerForTest so handler
+// tests can invoke it directly via httptest.
+func createIncidentHandler(svc *incident.Service, logger *slog.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		dec := json.NewDecoder(r.Body)
+		dec.DisallowUnknownFields()
+		var req createIncidentReq
+		if err := dec.Decode(&req); err != nil {
+			// Surface the decoder's message so clients can
+			// distinguish "json: unknown field \"x\"" from a
+			// genuinely malformed body. The encoding/json
+			// messages are stable across Go versions and don't
+			// leak server internals.
+			writeJSONError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		if req.Component == "" {
+			writeJSONError(w, http.StatusBadRequest, "component required")
+			return
+		}
+		inc, err := svc.CreateIncident(r.Context(), req.Component, req.Title)
+		switch {
+		case errors.Is(err, incident.ErrTitleRequired):
+			writeJSONError(w, http.StatusBadRequest, "title required")
+			return
+		case errors.Is(err, incident.ErrUnknownComponent):
+			writeJSONError(w, http.StatusBadRequest, "unknown component")
+			return
+		case err != nil:
+			logger.Error("incidents: CreateIncident failed", "err", err)
+			http.Error(w, "store error", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(toAPIIncident(inc))
+	}
+}
+
+func writeJSONError(w http.ResponseWriter, code int, msg string) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}
+
+// CreateIncidentHandlerForTest returns the POST /incidents handler
+// without registering it on a router. Test-only export to support
+// direct httptest invocation while the production wiring remains in
+// #21. Do not use from production code.
+func CreateIncidentHandlerForTest(svc *incident.Service, logger *slog.Logger) http.HandlerFunc {
+	return createIncidentHandler(svc, logger)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 
 	"github.com/northwatchlabs/northwatch/internal/component"
+	"github.com/northwatchlabs/northwatch/internal/incident"
 	"github.com/northwatchlabs/northwatch/internal/store"
 	"github.com/northwatchlabs/northwatch/internal/ui"
 )
@@ -45,8 +46,11 @@ func New(logger *slog.Logger, st store.Store) (http.Handler, error) {
 		_, _ = w.Write([]byte("ok\n"))
 	})
 
+	incSvc := incident.NewService(st, logger)
+
 	r.Handle("/static/*", http.StripPrefix("/static/", http.FileServerFS(staticFS)))
 	r.Get("/api/components", apiComponentsHandler(st, logger))
+	r.Get("/api/incidents", apiIncidentsHandler(incSvc, logger))
 	r.Get("/", indexHandler(tmpl, st, logger))
 
 	return r, nil

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/northwatchlabs/northwatch/internal/component"
+	"github.com/northwatchlabs/northwatch/internal/incident"
 	"github.com/northwatchlabs/northwatch/internal/server"
 	"github.com/northwatchlabs/northwatch/internal/store"
 )
@@ -206,5 +207,268 @@ func TestAPIComponents_StoreError(t *testing.T) {
 
 	if rr.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", rr.Code)
+	}
+}
+
+// newHandlerWithStore is like newHandler but also returns the store
+// so tests can seed incidents (which require a store handle rather
+// than going through any *server.Server exported API).
+func newHandlerWithStore(t *testing.T, seed ...component.Component) (http.Handler, *store.SQLite) {
+	t.Helper()
+	ctx := context.Background()
+	st, err := store.OpenSQLite(ctx, ":memory:")
+	if err != nil {
+		t.Fatalf("OpenSQLite: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	for _, c := range seed {
+		if err := st.UpsertComponent(ctx, c); err != nil {
+			t.Fatalf("UpsertComponent: %v", err)
+		}
+	}
+	h, err := server.New(slog.New(slog.NewTextHandler(io.Discard, nil)), st)
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+	return h, st
+}
+
+// seedIncident inserts one active incident + first update directly via
+// the store interface. Returns the incident ID. If resolved is true,
+// flips resolved_at via direct SQL after the insert.
+func seedIncident(t *testing.T, st *store.SQLite, componentID, title string, openedAt time.Time, resolved bool) string {
+	t.Helper()
+	incID := incident.NewID()
+	inc := incident.Incident{
+		ID: incID, ComponentID: componentID, Title: title,
+		Status: incident.StatusInvestigating, OpenedAt: openedAt,
+	}
+	upd := incident.Update{
+		ID: incident.NewID(), IncidentID: incID, Body: title,
+		Status: incident.StatusInvestigating, CreatedAt: openedAt,
+	}
+	if err := st.CreateIncident(context.Background(), inc, upd); err != nil {
+		t.Fatalf("CreateIncident: %v", err)
+	}
+	if resolved {
+		if _, err := st.DB().ExecContext(context.Background(),
+			`UPDATE incidents SET resolved_at = ? WHERE id = ?`,
+			openedAt.Unix(), incID); err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+	}
+	return incID
+}
+
+func TestGetAPIIncidentsEmpty(t *testing.T) {
+	h, _ := newHandlerWithStore(t)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/incidents", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	body := strings.TrimSpace(rr.Body.String())
+	if body != "[]" {
+		t.Errorf("body = %q, want %q", body, "[]")
+	}
+}
+
+func TestGetAPIIncidentsActiveOnly(t *testing.T) {
+	h, st := newHandlerWithStore(t, component.Component{
+		Kind: "Deployment", Namespace: "default", Name: "web",
+	})
+	now := time.Unix(1_700_000_000, 0).UTC()
+	_ = seedIncident(t, st, "Deployment/default/web", "active", now, false)
+	_ = seedIncident(t, st, "Deployment/default/web", "resolved", now, true)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/incidents", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	var got []map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1 (active only)", len(got))
+	}
+	if got[0]["title"] != "active" {
+		t.Errorf("title = %v, want active", got[0]["title"])
+	}
+}
+
+func TestGetAPIIncidentsIncludeResolved(t *testing.T) {
+	h, st := newHandlerWithStore(t, component.Component{
+		Kind: "Deployment", Namespace: "default", Name: "web",
+	})
+	now := time.Unix(1_700_000_000, 0).UTC()
+	_ = seedIncident(t, st, "Deployment/default/web", "active", now, false)
+	_ = seedIncident(t, st, "Deployment/default/web", "resolved", now, true)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/incidents?include=resolved", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	var got []map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+}
+
+func TestGetAPIIncidentsCacheControlNoStore(t *testing.T) {
+	h, _ := newHandlerWithStore(t)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/incidents", nil))
+	if got := rr.Header().Get("Cache-Control"); got != "no-store" {
+		t.Errorf("Cache-Control = %q, want no-store", got)
+	}
+}
+
+// newPostHandler builds a createIncidentHandler bound to a fresh
+// in-memory store seeded with the given components. Returns the
+// handler and the store so the test can assert side effects.
+func newPostHandler(t *testing.T, seed ...component.Component) (http.HandlerFunc, *store.SQLite) {
+	t.Helper()
+	ctx := context.Background()
+	st, err := store.OpenSQLite(ctx, ":memory:")
+	if err != nil {
+		t.Fatalf("OpenSQLite: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	for _, c := range seed {
+		if err := st.UpsertComponent(ctx, c); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	svc := incident.NewService(st, logger)
+	return server.CreateIncidentHandlerForTest(svc, logger), st
+}
+
+func TestCreateIncidentHandlerCreated(t *testing.T) {
+	h, _ := newPostHandler(t, component.Component{
+		Kind: "Deployment", Namespace: "default", Name: "web",
+	})
+	body := strings.NewReader(`{"component":"Deployment/default/web","title":"Pods down"}`)
+	req := httptest.NewRequest(http.MethodPost, "/incidents", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body=%s", rr.Code, rr.Body.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got["status"] != "investigating" {
+		t.Errorf("status = %v, want investigating", got["status"])
+	}
+	if got["title"] != "Pods down" {
+		t.Errorf("title = %v, want Pods down", got["title"])
+	}
+	if id, _ := got["id"].(string); len(id) != 26 {
+		t.Errorf("id length = %d, want 26 (ULID)", len(id))
+	}
+	if _, present := got["resolvedAt"]; present {
+		t.Errorf("resolvedAt should be omitted when nil")
+	}
+}
+
+func TestCreateIncidentHandlerMissingTitle(t *testing.T) {
+	h, _ := newPostHandler(t, component.Component{
+		Kind: "Deployment", Namespace: "default", Name: "web",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/incidents",
+		strings.NewReader(`{"component":"Deployment/default/web","title":""}`))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rr.Code)
+	}
+	if !strings.Contains(rr.Body.String(), "title required") {
+		t.Errorf("body = %s, want contains title required", rr.Body.String())
+	}
+}
+
+func TestCreateIncidentHandlerMissingComponent(t *testing.T) {
+	h, _ := newPostHandler(t)
+	req := httptest.NewRequest(http.MethodPost, "/incidents",
+		strings.NewReader(`{"title":"oops"}`))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rr.Code)
+	}
+	if !strings.Contains(rr.Body.String(), "component required") {
+		t.Errorf("body = %s, want contains component required", rr.Body.String())
+	}
+}
+
+func TestCreateIncidentHandlerUnknownComponent(t *testing.T) {
+	h, _ := newPostHandler(t) // no seeded components
+	req := httptest.NewRequest(http.MethodPost, "/incidents",
+		strings.NewReader(`{"component":"Deployment/default/ghost","title":"x"}`))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rr.Code)
+	}
+	if !strings.Contains(rr.Body.String(), "unknown component") {
+		t.Errorf("body = %s, want contains unknown component", rr.Body.String())
+	}
+}
+
+func TestCreateIncidentHandlerUnknownJSONField(t *testing.T) {
+	h, _ := newPostHandler(t, component.Component{
+		Kind: "Deployment", Namespace: "default", Name: "web",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/incidents",
+		strings.NewReader(`{"component":"Deployment/default/web","title":"x","mystery":1}`))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rr.Code)
+	}
+	if !strings.Contains(rr.Body.String(), "unknown field") {
+		t.Errorf("body = %s, want contains 'unknown field' (decoder error should be surfaced)", rr.Body.String())
+	}
+}
+
+func TestCreateIncidentHandlerMalformedJSON(t *testing.T) {
+	h, _ := newPostHandler(t)
+	req := httptest.NewRequest(http.MethodPost, "/incidents",
+		strings.NewReader(`{not-json`))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rr.Code)
+	}
+}
+
+func TestPostIncidentsRouteNotRegistered(t *testing.T) {
+	h, _ := newHandlerWithStore(t)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/incidents",
+		strings.NewReader(`{"component":"x","title":"y"}`))
+	h.ServeHTTP(rr, req)
+	// chi returns 405 Method Not Allowed when a method is missing
+	// on an otherwise-registered path, or 404 when the path is
+	// unregistered. Either confirms the POST route is not wired.
+	if rr.Code != http.StatusNotFound && rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("POST /incidents status = %d, want 404 or 405 "+
+			"(route must be deferred to #21)", rr.Code)
 	}
 }

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/northwatchlabs/northwatch/internal/component"
+	"github.com/northwatchlabs/northwatch/internal/incident"
 	_ "modernc.org/sqlite"
 )
 
@@ -110,6 +111,27 @@ func (s *SQLite) GetComponent(ctx context.Context, id string) (component.Compone
 	c.Status = component.Status(status)
 	c.UpdatedAt = time.Unix(ts, 0).UTC()
 	return c, nil
+}
+
+const stmtHasActiveComponent = `
+SELECT 1 FROM components WHERE id = ? AND active = 1;
+`
+
+// HasActiveComponent returns true iff a row matching id exists with
+// active = 1. The result is intended for guard checks (e.g., the
+// incident service rejecting incident creation against deactivated
+// components). Returns false (not ErrNotFound) for both missing and
+// inactive rows because callers don't need to distinguish.
+func (s *SQLite) HasActiveComponent(ctx context.Context, id string) (bool, error) {
+	var one int
+	err := s.db.QueryRowContext(ctx, stmtHasActiveComponent, id).Scan(&one)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 const stmtListComponents = `
@@ -338,4 +360,155 @@ func dsnFromPath(p string) string {
 	// `/tmp/db?x=1` would silently open the wrong file and let an
 	// attacker-controlled string override our pragmas.
 	return "file:" + url.PathEscape(p) + "?_pragma=journal_mode(WAL)&" + pragmas
+}
+
+const stmtInsertIncident = `
+INSERT INTO incidents (id, component_id, title, status, opened_at)
+VALUES (?, ?, ?, ?, ?);
+`
+
+const stmtInsertIncidentUpdate = `
+INSERT INTO incident_updates (id, incident_id, body, status, created_at)
+VALUES (?, ?, ?, ?, ?);
+`
+
+// CreateIncident inserts inc and firstUpdate in a single
+// BEGIN IMMEDIATE transaction. The pattern matches SyncComponents:
+// both writes run on a single *sql.Conn that holds the write lock,
+// and a deferred ROLLBACK guard uses context.Background() so a
+// cancelled parent ctx cannot bypass cleanup.
+func (s *SQLite) CreateIncident(ctx context.Context, inc incident.Incident, firstUpdate incident.Update) error {
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("store: acquire conn: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		return fmt.Errorf("store: begin immediate: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(context.Background(), "ROLLBACK")
+		}
+	}()
+
+	if _, err := conn.ExecContext(ctx, stmtInsertIncident,
+		inc.ID, inc.ComponentID, inc.Title, string(inc.Status), inc.OpenedAt.UTC().Unix(),
+	); err != nil {
+		return translateFKAsNotFound(err)
+	}
+	if _, err := conn.ExecContext(ctx, stmtInsertIncidentUpdate,
+		firstUpdate.ID, firstUpdate.IncidentID, firstUpdate.Body,
+		string(firstUpdate.Status), firstUpdate.CreatedAt.UTC().Unix(),
+	); err != nil {
+		return fmt.Errorf("store: insert incident_update: %w", err)
+	}
+
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return fmt.Errorf("store: commit: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+// translateFKAsNotFound maps a SQLite FK violation (extended code
+// 787, SQLITE_CONSTRAINT_FOREIGNKEY) into ErrNotFound so callers
+// don't have to parse driver-specific error text. Any other error
+// is returned as-is, wrapped.
+func translateFKAsNotFound(err error) error {
+	if err == nil {
+		return nil
+	}
+	// modernc.org/sqlite returns an error whose Error() string
+	// contains "FOREIGN KEY constraint failed" on FK violation.
+	// String-matching is the documented contract for this driver.
+	if strings.Contains(err.Error(), "FOREIGN KEY constraint failed") {
+		return ErrNotFound
+	}
+	return fmt.Errorf("store: insert incident: %w", err)
+}
+
+const stmtGetIncident = `
+SELECT id, component_id, title, status, opened_at, resolved_at
+FROM incidents WHERE id = ?;
+`
+
+const stmtGetActiveIncident = `
+SELECT id, component_id, title, status, opened_at, resolved_at
+FROM incidents
+WHERE resolved_at IS NULL
+ORDER BY opened_at DESC
+LIMIT 1;
+`
+
+func (s *SQLite) GetIncident(ctx context.Context, id string) (incident.Incident, error) {
+	row := s.db.QueryRowContext(ctx, stmtGetIncident, id)
+	return scanIncident(row.Scan)
+}
+
+func (s *SQLite) GetActiveIncident(ctx context.Context) (incident.Incident, error) {
+	row := s.db.QueryRowContext(ctx, stmtGetActiveIncident)
+	return scanIncident(row.Scan)
+}
+
+// scanIncident is shared between Get* and List* row scans. The
+// scan argument is row.Scan or rows.Scan so the helper works for
+// both *sql.Row and *sql.Rows.
+func scanIncident(scan func(...any) error) (incident.Incident, error) {
+	var (
+		inc        incident.Incident
+		status     string
+		openedSecs int64
+		resolved   sql.NullInt64
+	)
+	err := scan(&inc.ID, &inc.ComponentID, &inc.Title, &status, &openedSecs, &resolved)
+	if errors.Is(err, sql.ErrNoRows) {
+		return incident.Incident{}, ErrNotFound
+	}
+	if err != nil {
+		return incident.Incident{}, err
+	}
+	inc.Status = incident.Status(status)
+	inc.OpenedAt = time.Unix(openedSecs, 0).UTC()
+	if resolved.Valid {
+		t := time.Unix(resolved.Int64, 0).UTC()
+		inc.ResolvedAt = &t
+	}
+	return inc, nil
+}
+
+const stmtListIncidentsActive = `
+SELECT id, component_id, title, status, opened_at, resolved_at
+FROM incidents WHERE resolved_at IS NULL
+ORDER BY opened_at DESC;
+`
+
+const stmtListIncidentsAll = `
+SELECT id, component_id, title, status, opened_at, resolved_at
+FROM incidents
+ORDER BY opened_at DESC;
+`
+
+func (s *SQLite) ListIncidents(ctx context.Context, includeResolved bool) ([]incident.Incident, error) {
+	stmt := stmtListIncidentsActive
+	if includeResolved {
+		stmt = stmtListIncidentsAll
+	}
+	rows, err := s.db.QueryContext(ctx, stmt)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []incident.Incident
+	for rows.Next() {
+		inc, err := scanIncident(rows.Scan)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, inc)
+	}
+	return out, rows.Err()
 }

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/northwatchlabs/northwatch/internal/component"
+	"github.com/northwatchlabs/northwatch/internal/incident"
 	"github.com/northwatchlabs/northwatch/internal/store"
 )
 
@@ -613,6 +614,144 @@ func TestSyncComponents_DeactivatedCountIgnoresAlreadyInactive(t *testing.T) {
 	}
 }
 
+func TestCreateIncidentInsertsBothRows(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	seedComponent(t, s, component.Component{
+		Kind: "Deployment", Namespace: "default", Name: "web",
+	})
+
+	now := time.Unix(1_700_000_000, 0).UTC()
+	inc := incident.Incident{
+		ID:          "01HXINC0000000000000000001",
+		ComponentID: "Deployment/default/web",
+		Title:       "Pods crashlooping",
+		Status:      incident.StatusInvestigating,
+		OpenedAt:    now,
+	}
+	upd := incident.Update{
+		ID:         "01HXUPD0000000000000000001",
+		IncidentID: inc.ID,
+		Body:       inc.Title,
+		Status:     incident.StatusInvestigating,
+		CreatedAt:  now,
+	}
+
+	if err := s.CreateIncident(ctx, inc, upd); err != nil {
+		t.Fatalf("CreateIncident: %v", err)
+	}
+
+	var incidentCount, updateCount int
+	if err := s.DB().QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM incidents WHERE id = ?`, inc.ID).Scan(&incidentCount); err != nil {
+		t.Fatalf("count incidents: %v", err)
+	}
+	if incidentCount != 1 {
+		t.Fatalf("incidents row count = %d, want 1", incidentCount)
+	}
+	if err := s.DB().QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM incident_updates WHERE incident_id = ?`, inc.ID).Scan(&updateCount); err != nil {
+		t.Fatalf("count updates: %v", err)
+	}
+	if updateCount != 1 {
+		t.Fatalf("incident_updates row count = %d, want 1", updateCount)
+	}
+}
+
+func TestCreateIncidentUnknownComponent(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	now := time.Unix(1_700_000_000, 0).UTC()
+	inc := incident.Incident{
+		ID:          "01HXINC0000000000000000002",
+		ComponentID: "Deployment/default/missing",
+		Title:       "nope",
+		Status:      incident.StatusInvestigating,
+		OpenedAt:    now,
+	}
+	upd := incident.Update{
+		ID:         "01HXUPD0000000000000000002",
+		IncidentID: inc.ID,
+		Body:       inc.Title,
+		Status:     incident.StatusInvestigating,
+		CreatedAt:  now,
+	}
+
+	err := s.CreateIncident(ctx, inc, upd)
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("CreateIncident err = %v, want ErrNotFound", err)
+	}
+
+	var n int
+	if err := s.DB().QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM incidents`).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("incidents row count = %d after FK failure, want 0", n)
+	}
+}
+
+func TestCreateIncidentAtomicityRollsBackOnUpdateFailure(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	seedComponent(t, s, component.Component{
+		Kind: "Deployment", Namespace: "default", Name: "web",
+	})
+
+	now := time.Unix(1_700_000_000, 0).UTC()
+	dupUpdateID := "01HXUPD0000000000000000099"
+
+	first := incident.Incident{
+		ID:          "01HXINC0000000000000000010",
+		ComponentID: "Deployment/default/web",
+		Title:       "first",
+		Status:      incident.StatusInvestigating,
+		OpenedAt:    now,
+	}
+	firstUpd := incident.Update{
+		ID:         dupUpdateID,
+		IncidentID: first.ID,
+		Body:       first.Title,
+		Status:     incident.StatusInvestigating,
+		CreatedAt:  now,
+	}
+	if err := s.CreateIncident(ctx, first, firstUpd); err != nil {
+		t.Fatalf("seed first incident: %v", err)
+	}
+
+	collide := incident.Incident{
+		ID:          "01HXINC0000000000000000011",
+		ComponentID: "Deployment/default/web",
+		Title:       "second",
+		Status:      incident.StatusInvestigating,
+		OpenedAt:    now,
+	}
+	collideUpd := incident.Update{
+		ID:         dupUpdateID, // collision
+		IncidentID: collide.ID,
+		Body:       collide.Title,
+		Status:     incident.StatusInvestigating,
+		CreatedAt:  now,
+	}
+
+	if err := s.CreateIncident(ctx, collide, collideUpd); err == nil {
+		t.Fatal("CreateIncident: want error from duplicate update id, got nil")
+	}
+
+	var n int
+	if err := s.DB().QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM incidents WHERE id = ?`, collide.ID).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("incidents row count = %d after rollback, want 0", n)
+	}
+}
+
 func TestSyncComponents_RefusalDoesNotApplyUpserts(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()
@@ -638,5 +777,208 @@ func TestSyncComponents_RefusalDoesNotApplyUpserts(t *testing.T) {
 	}
 	if c.DisplayName != "old" {
 		t.Errorf("DisplayName = %q, want %q (upsert must have rolled back)", c.DisplayName, "old")
+	}
+}
+
+func TestGetActiveIncidentReturnsMostRecent(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	seedComponent(t, s, component.Component{
+		Kind: "Deployment", Namespace: "default", Name: "web",
+	})
+
+	mk := func(id string, secs int64) {
+		t.Helper()
+		opened := time.Unix(secs, 0).UTC()
+		if err := s.CreateIncident(ctx,
+			incident.Incident{
+				ID:          id,
+				ComponentID: "Deployment/default/web",
+				Title:       id,
+				Status:      incident.StatusInvestigating,
+				OpenedAt:    opened,
+			},
+			incident.Update{
+				ID:         "u-" + id,
+				IncidentID: id,
+				Body:       id,
+				Status:     incident.StatusInvestigating,
+				CreatedAt:  opened,
+			},
+		); err != nil {
+			t.Fatalf("seed %s: %v", id, err)
+		}
+	}
+	mk("01HXINC00000000000000000A1", 100)
+	mk("01HXINC00000000000000000A2", 300) // latest
+	mk("01HXINC00000000000000000A3", 200)
+
+	got, err := s.GetActiveIncident(ctx)
+	if err != nil {
+		t.Fatalf("GetActiveIncident: %v", err)
+	}
+	if got.ID != "01HXINC00000000000000000A2" {
+		t.Fatalf("GetActiveIncident.ID = %s, want 01HXINC00000000000000000A2", got.ID)
+	}
+}
+
+func TestHasActiveComponentTrueForActive(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedComponent(t, s, component.Component{
+		Kind: "Deployment", Namespace: "default", Name: "web",
+	})
+	ok, err := s.HasActiveComponent(ctx, "Deployment/default/web")
+	if err != nil {
+		t.Fatalf("HasActiveComponent: %v", err)
+	}
+	if !ok {
+		t.Fatalf("HasActiveComponent = false, want true")
+	}
+}
+
+func TestHasActiveComponentFalseForInactive(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedComponent(t, s, component.Component{
+		Kind: "Deployment", Namespace: "default", Name: "web",
+	})
+	if _, err := s.DB().ExecContext(ctx,
+		`UPDATE components SET active = 0 WHERE id = ?`,
+		"Deployment/default/web"); err != nil {
+		t.Fatalf("deactivate: %v", err)
+	}
+	ok, err := s.HasActiveComponent(ctx, "Deployment/default/web")
+	if err != nil {
+		t.Fatalf("HasActiveComponent: %v", err)
+	}
+	if ok {
+		t.Fatalf("HasActiveComponent = true, want false (deactivated)")
+	}
+}
+
+func TestHasActiveComponentFalseForMissing(t *testing.T) {
+	s := newTestStore(t)
+	ok, err := s.HasActiveComponent(context.Background(), "Deployment/default/ghost")
+	if err != nil {
+		t.Fatalf("HasActiveComponent: %v", err)
+	}
+	if ok {
+		t.Fatalf("HasActiveComponent = true, want false (missing)")
+	}
+}
+
+func TestGetActiveIncidentNoneReturnsErrNotFound(t *testing.T) {
+	s := newTestStore(t)
+	_, err := s.GetActiveIncident(context.Background())
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("GetActiveIncident err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestGetIncidentNotFound(t *testing.T) {
+	s := newTestStore(t)
+	_, err := s.GetIncident(context.Background(), "missing")
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("GetIncident err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestListIncidentsExcludesResolvedByDefault(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	seedComponent(t, s, component.Component{
+		Kind: "Deployment", Namespace: "default", Name: "web",
+	})
+
+	now := time.Unix(1_700_000_000, 0).UTC()
+	active := incident.Incident{
+		ID: "01HXINC0000000000000000B1", ComponentID: "Deployment/default/web",
+		Title: "active", Status: incident.StatusInvestigating, OpenedAt: now,
+	}
+	resolved := incident.Incident{
+		ID: "01HXINC0000000000000000B2", ComponentID: "Deployment/default/web",
+		Title: "resolved", Status: incident.StatusResolved, OpenedAt: now,
+	}
+	mkUpd := func(id string) incident.Update {
+		return incident.Update{
+			ID: "u-" + id, IncidentID: id, Body: "x",
+			Status: incident.StatusInvestigating, CreatedAt: now,
+		}
+	}
+	if err := s.CreateIncident(ctx, active, mkUpd(active.ID)); err != nil {
+		t.Fatalf("seed active: %v", err)
+	}
+	if err := s.CreateIncident(ctx, resolved, mkUpd(resolved.ID)); err != nil {
+		t.Fatalf("seed resolved: %v", err)
+	}
+	// Mark the second one resolved.
+	if _, err := s.DB().ExecContext(ctx,
+		`UPDATE incidents SET resolved_at = ? WHERE id = ?`,
+		now.Unix(), resolved.ID); err != nil {
+		t.Fatalf("mark resolved: %v", err)
+	}
+
+	got, err := s.ListIncidents(ctx, false)
+	if err != nil {
+		t.Fatalf("ListIncidents(false): %v", err)
+	}
+	if len(got) != 1 || got[0].ID != active.ID {
+		t.Fatalf("ListIncidents(false) = %v, want [active]", got)
+	}
+
+	gotAll, err := s.ListIncidents(ctx, true)
+	if err != nil {
+		t.Fatalf("ListIncidents(true): %v", err)
+	}
+	if len(gotAll) != 2 {
+		t.Fatalf("ListIncidents(true) len = %d, want 2", len(gotAll))
+	}
+}
+
+func TestListIncidentsOrderedByOpenedAtDesc(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	seedComponent(t, s, component.Component{
+		Kind: "Deployment", Namespace: "default", Name: "web",
+	})
+
+	mk := func(id string, secs int64) {
+		t.Helper()
+		opened := time.Unix(secs, 0).UTC()
+		_ = s.CreateIncident(ctx,
+			incident.Incident{
+				ID: id, ComponentID: "Deployment/default/web",
+				Title: id, Status: incident.StatusInvestigating, OpenedAt: opened,
+			},
+			incident.Update{
+				ID: "u-" + id, IncidentID: id, Body: id,
+				Status: incident.StatusInvestigating, CreatedAt: opened,
+			},
+		)
+	}
+	mk("01HXINC0000000000000000C1", 100)
+	mk("01HXINC0000000000000000C2", 300)
+	mk("01HXINC0000000000000000C3", 200)
+
+	got, err := s.ListIncidents(ctx, false)
+	if err != nil {
+		t.Fatalf("ListIncidents: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3", len(got))
+	}
+	wantOrder := []string{
+		"01HXINC0000000000000000C2",
+		"01HXINC0000000000000000C3",
+		"01HXINC0000000000000000C1",
+	}
+	for i, w := range wantOrder {
+		if got[i].ID != w {
+			t.Errorf("got[%d].ID = %s, want %s", i, got[i].ID, w)
+		}
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -9,10 +9,13 @@ import (
 	"fmt"
 
 	"github.com/northwatchlabs/northwatch/internal/component"
+	"github.com/northwatchlabs/northwatch/internal/incident"
 )
 
 // ErrNotFound is returned by Get* methods when no row matches.
-var ErrNotFound = errors.New("store: not found")
+// It is the same sentinel as incident.ErrNotFound — they share a
+// single value so callers can use either reference with errors.Is.
+var ErrNotFound = incident.ErrNotFound
 
 // ErrSchemaTooNew is returned by Migrate when the on-disk schema
 // version is higher than the maximum migration embedded in this
@@ -72,6 +75,12 @@ type Store interface {
 	// ErrNotFound if no row matches.
 	GetComponent(ctx context.Context, id string) (component.Component, error)
 
+	// HasActiveComponent returns true if a component with the given ID
+	// exists AND has active = 1. Returns (false, nil) when the row is
+	// missing or soft-deactivated. Storage errors are returned as
+	// (false, err).
+	HasActiveComponent(ctx context.Context, id string) (bool, error)
+
 	// UpsertComponent inserts or updates by id. The store computes id
 	// from (Kind, Namespace, Name) — SQLite uses a STORED generated
 	// column — and stamps updated_at to time.Now().UTC().Unix().
@@ -95,4 +104,24 @@ type Store interface {
 	// been deactivated and rolls back. Returns the count of rows
 	// newly transitioned from active=1 to active=0 in this call.
 	SyncComponents(ctx context.Context, specs []ComponentSpec, allowDeactivate bool) (deactivated int, err error)
+
+	// CreateIncident inserts the incident and its initial
+	// incident_updates row in a single BEGIN IMMEDIATE transaction.
+	// Returns ErrNotFound if inc.ComponentID does not match a row in
+	// the components table (FK violation is translated). Both rows
+	// land or neither does.
+	CreateIncident(ctx context.Context, inc incident.Incident, firstUpdate incident.Update) error
+
+	// GetIncident returns the incident with the given ID, or
+	// ErrNotFound.
+	GetIncident(ctx context.Context, id string) (incident.Incident, error)
+
+	// GetActiveIncident returns the most recently opened incident
+	// whose resolved_at IS NULL, or ErrNotFound when none exist.
+	GetActiveIncident(ctx context.Context) (incident.Incident, error)
+
+	// ListIncidents returns incidents ordered by opened_at DESC.
+	// When includeResolved is false, rows with resolved_at IS NOT
+	// NULL are excluded.
+	ListIncidents(ctx context.Context, includeResolved bool) ([]incident.Incident, error)
 }

--- a/internal/watcher/deployment_test.go
+++ b/internal/watcher/deployment_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/northwatchlabs/northwatch/internal/component"
 	"github.com/northwatchlabs/northwatch/internal/config"
+	"github.com/northwatchlabs/northwatch/internal/incident"
 	"github.com/northwatchlabs/northwatch/internal/store"
 )
 
@@ -57,8 +58,23 @@ func (s *recordStore) UpsertComponent(_ context.Context, c component.Component) 
 	}
 	return nil
 }
+func (s *recordStore) HasActiveComponent(context.Context, string) (bool, error) {
+	return false, nil
+}
 func (s *recordStore) SyncComponents(context.Context, []store.ComponentSpec, bool) (int, error) {
 	return 0, nil
+}
+func (s *recordStore) CreateIncident(context.Context, incident.Incident, incident.Update) error {
+	return nil
+}
+func (s *recordStore) GetIncident(context.Context, string) (incident.Incident, error) {
+	return incident.Incident{}, store.ErrNotFound
+}
+func (s *recordStore) GetActiveIncident(context.Context) (incident.Incident, error) {
+	return incident.Incident{}, store.ErrNotFound
+}
+func (s *recordStore) ListIncidents(context.Context, bool) ([]incident.Incident, error) {
+	return nil, nil
 }
 
 func (s *recordStore) count() int {


### PR DESCRIPTION
## Summary

- Adds the `internal/incident` package — domain types (`Incident`, `Update`, `Status`), sentinel errors, ULID generator, and the `Service` use-case layer with injectable clock/ID for tests.
- Extends the store with four incident methods. `CreateIncident` writes the incident plus its first `incident_updates` row in a single `BEGIN IMMEDIATE` transaction; FK violations on `component_id` translate to `ErrNotFound`. `ListIncidents` filters resolved by default; `?include=resolved` returns everything.
- `Service.CreateIncident` validates the target component via the new `HasActiveComponent` store method, so soft-deactivated components are rejected with `ErrUnknownComponent`.
- Wires `GET /api/incidents` into `server.New`. Returns `[]` for empty (not `null`); sets `Cache-Control: no-store` consistent with `/api/components`.
- Ships `createIncidentHandler` (POST handler function) but does **not** register it on the router. Codex pre-review flagged shipping an unauthenticated write endpoint before bearer-token middleware lands; route registration moves to #21 so the endpoint never appears unauthenticated.
- Consolidates `ErrNotFound` in the `incident` package; `store.ErrNotFound` aliases it. This breaks what would otherwise be a circular dependency between the service and store packages.

The issue's original acceptance criteria included `curl POST /incidents` returning 201 — that verification moves to #21 with the route registration. This PR's `TestPostIncidentsRouteNotRegistered` locks in the deferred wiring decision.

Closes #20

## Test plan

- [x] `go test ./...` green
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` reports 0 issues
- [x] `POST /incidents` returns 404 through the wired router
- [x] `GET /api/incidents` returns `[]` for empty store, active rows by default, all rows when `?include=resolved` is set
- [x] `Cache-Control: no-store` header present on `GET /api/incidents`
- [x] `CreateIncident` rolls back the incident row if the `incident_updates` insert fails (atomicity)
- [x] `CreateIncident` rejects incidents targeting soft-deactivated components with `ErrUnknownComponent`