### PR TITLE
Add bearer-token middleware and idempotent resolve endpoint

### DIFF
--- a/cmd/northwatch/main.go
+++ b/cmd/northwatch/main.go
@@ -66,6 +66,9 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "  --kubeconfig       Explicit kubeconfig path (overrides in-cluster credentials)")
 	fmt.Fprintln(os.Stderr, "  --kube-context     Context within the resolved kubeconfig")
 	fmt.Fprintln(os.Stderr, "  --no-cluster       Skip cluster connectivity (local-only run)")
+	fmt.Fprintln(os.Stderr, "  --api-token        Bearer token for write endpoints (>=16 chars).")
+	fmt.Fprintln(os.Stderr, "                     Reads NORTHWATCH_API_TOKEN env when unset.")
+	fmt.Fprintln(os.Stderr, "                     Empty disables writes (POSTs return 401).")
 }
 
 func serveCmd(args []string) int {
@@ -87,6 +90,9 @@ func serveCmd(args []string) int {
 	noCluster := fs.Bool("no-cluster",
 		envOrBool("NORTHWATCH_NO_CLUSTER", false),
 		"Skip cluster connectivity (local-only run)")
+	apiToken := fs.String("api-token",
+		envOr("NORTHWATCH_API_TOKEN", ""),
+		"Bearer token gating POST endpoints (>=16 chars). Empty disables writes.")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return 0
@@ -95,6 +101,20 @@ func serveCmd(args []string) int {
 	}
 
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+
+	switch {
+	case *apiToken == "":
+		logger.Warn("API write endpoints disabled — set NORTHWATCH_API_TOKEN to enable.")
+	case len(*apiToken) < 16:
+		// Boot must fail rather than silently accept a weak token —
+		// any configured token is a deliberate signal that writes
+		// should be reachable, and shipping with a short token would
+		// invite trivial brute-force attempts.
+		logger.Error("api token too short", "min_length", 16)
+		return 1
+	default:
+		logger.Info("api token configured")
+	}
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
@@ -121,7 +141,7 @@ func serveCmd(args []string) int {
 		return 1
 	}
 
-	h, err := server.New(logger, st)
+	h, err := server.New(logger, st, *apiToken)
 	if err != nil {
 		logger.Error("server init failed", "err", err)
 		return 1

--- a/internal/incident/service.go
+++ b/internal/incident/service.go
@@ -17,6 +17,13 @@ type Store interface {
 	CreateIncident(ctx context.Context, inc Incident, firstUpdate Update) error
 	GetActiveIncident(ctx context.Context) (Incident, error)
 	ListIncidents(ctx context.Context, includeResolved bool) ([]Incident, error)
+	ResolveIncident(
+		ctx context.Context,
+		id string,
+		resolvedAt time.Time,
+		updateID string,
+		updateBody string,
+	) (Incident, error)
 }
 
 // Service is the use-case layer for incidents. It validates input,
@@ -91,6 +98,16 @@ func (s *Service) GetActiveIncident(ctx context.Context) (Incident, error) {
 // includeResolved is false, resolved rows are excluded.
 func (s *Service) ListIncidents(ctx context.Context, includeResolved bool) ([]Incident, error) {
 	return s.st.ListIncidents(ctx, includeResolved)
+}
+
+// ResolveIncident marks an incident resolved. Idempotent: resolving
+// an already-resolved incident is a no-op that returns the existing
+// resolved incident with its original ResolvedAt. The transactional
+// store guarantees two concurrent resolvers agree on the post-state.
+//
+// Returns store.ErrNotFound if no incident has the given ID.
+func (s *Service) ResolveIncident(ctx context.Context, id string) (Incident, error) {
+	return s.st.ResolveIncident(ctx, id, s.now(), s.newID(), "Incident resolved.")
 }
 
 // SetClockForTest overrides the time source. Test-only.

--- a/internal/incident/service_test.go
+++ b/internal/incident/service_test.go
@@ -131,3 +131,117 @@ func TestCreateIncidentDeterministicWithInjectedClockAndID(t *testing.T) {
 		t.Errorf("OpenedAt = %v, want %v", got.OpenedAt, fixed)
 	}
 }
+
+func TestResolveIncidentHappyPath(t *testing.T) {
+	svc, _ := newServiceWithStore(t)
+	ctx := context.Background()
+	created, err := svc.CreateIncident(ctx, "Deployment/default/web", "boom")
+	if err != nil {
+		t.Fatalf("CreateIncident: %v", err)
+	}
+
+	resolveAt := time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC)
+	svc.SetClockForTest(func() time.Time { return resolveAt })
+	svc.SetIDForTest(func() string { return "01HXUPD0000000000000RESV1" })
+
+	got, err := svc.ResolveIncident(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("ResolveIncident: %v", err)
+	}
+	if got.Status != incident.StatusResolved {
+		t.Errorf("Status = %s, want resolved", got.Status)
+	}
+	if got.ResolvedAt == nil || !got.ResolvedAt.Equal(resolveAt) {
+		t.Errorf("ResolvedAt = %v, want %v", got.ResolvedAt, resolveAt)
+	}
+}
+
+func TestResolveIncidentUnknown(t *testing.T) {
+	svc, _ := newServiceWithStore(t)
+	_, err := svc.ResolveIncident(context.Background(), "ghost-id")
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("err = %v, want store.ErrNotFound", err)
+	}
+}
+
+func TestResolveIncidentIdempotent(t *testing.T) {
+	svc, st := newServiceWithStore(t)
+	ctx := context.Background()
+	created, err := svc.CreateIncident(ctx, "Deployment/default/web", "boom")
+	if err != nil {
+		t.Fatalf("CreateIncident: %v", err)
+	}
+
+	firstAt := time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC)
+	svc.SetClockForTest(func() time.Time { return firstAt })
+	svc.SetIDForTest(func() string { return "01HXUPD0000000000000IDMP1" })
+	first, err := svc.ResolveIncident(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("first resolve: %v", err)
+	}
+
+	// Second resolve uses a *later* clock and a *different* ID.
+	secondAt := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	svc.SetClockForTest(func() time.Time { return secondAt })
+	svc.SetIDForTest(func() string { return "01HXUPD0000000000000IDMP2" })
+	second, err := svc.ResolveIncident(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("second resolve: %v", err)
+	}
+
+	// Both returns reflect the *first* resolve's timestamp.
+	if first.ResolvedAt == nil || !first.ResolvedAt.Equal(firstAt) {
+		t.Errorf("first.ResolvedAt = %v, want %v", first.ResolvedAt, firstAt)
+	}
+	if second.ResolvedAt == nil || !second.ResolvedAt.Equal(firstAt) {
+		t.Errorf("second.ResolvedAt = %v, want %v (idempotent)", second.ResolvedAt, firstAt)
+	}
+
+	// Only one resolve-update row landed (plus the create-time update = 2).
+	var n int
+	if err := st.DB().QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM incident_updates WHERE incident_id = ?`,
+		created.ID).Scan(&n); err != nil {
+		t.Fatalf("count updates: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("incident_updates count = %d, want 2 (idempotent resolve must not double-write)", n)
+	}
+}
+
+func TestResolveIncidentUsesInjectedClockAndID(t *testing.T) {
+	svc, st := newServiceWithStore(t)
+	ctx := context.Background()
+	created, err := svc.CreateIncident(ctx, "Deployment/default/web", "boom")
+	if err != nil {
+		t.Fatalf("CreateIncident: %v", err)
+	}
+
+	resolveAt := time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC)
+	resolveID := "01HXUPD0000000000000RSLV2"
+	svc.SetClockForTest(func() time.Time { return resolveAt })
+	svc.SetIDForTest(func() string { return resolveID })
+
+	if _, err := svc.ResolveIncident(ctx, created.ID); err != nil {
+		t.Fatalf("ResolveIncident: %v", err)
+	}
+
+	var (
+		body, status string
+		createdAt    int64
+	)
+	row := st.DB().QueryRowContext(ctx,
+		`SELECT body, status, created_at FROM incident_updates WHERE id = ?`, resolveID)
+	if err := row.Scan(&body, &status, &createdAt); err != nil {
+		t.Fatalf("scan resolve update: %v", err)
+	}
+	if body != "Incident resolved." {
+		t.Errorf("body = %q, want %q", body, "Incident resolved.")
+	}
+	if status != string(incident.StatusResolved) {
+		t.Errorf("status = %q, want %q", status, incident.StatusResolved)
+	}
+	if createdAt != resolveAt.Unix() {
+		t.Errorf("created_at = %d, want %d", createdAt, resolveAt.Unix())
+	}
+}

--- a/internal/server/auth/auth.go
+++ b/internal/server/auth/auth.go
@@ -1,0 +1,78 @@
+// Package auth provides the bearer-token middleware that gates
+// every write endpoint behind a shared secret.
+package auth
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strings"
+)
+
+// BearerToken returns middleware that requires
+// `Authorization: Bearer <expected>` on every request. The provided
+// token is compared with subtle.ConstantTimeCompare to avoid leaking
+// the expected value via timing.
+//
+// An empty expected token disables the wrapped routes: every request
+// returns 401 with body {"error":"write endpoints disabled"}. This
+// matches the "writes disabled" boot mode used when no
+// NORTHWATCH_API_TOKEN is configured.
+//
+// Failure responses always set Content-Type: application/json and
+// WWW-Authenticate: Bearer (RFC 6750 §3). The middleware never logs
+// token values — only the failure reason.
+func BearerToken(expected string, logger *slog.Logger) func(http.Handler) http.Handler {
+	// Compare fixed-size SHA-256 digests rather than the raw tokens.
+	// subtle.ConstantTimeCompare returns 0 immediately when lengths
+	// differ, which would leak the expected token's length via timing.
+	// Hashing first equalizes input size so the comparison is
+	// length-independent.
+	expectedHash := sha256.Sum256([]byte(expected))
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if expected == "" {
+				writeUnauthorized(w, "write endpoints disabled")
+				logger.Warn("auth_denied", "reason", "writes_disabled",
+					"method", r.Method, "path", r.URL.Path)
+				return
+			}
+
+			h := r.Header.Get("Authorization")
+			if h == "" {
+				writeUnauthorized(w, "unauthorized")
+				logger.Warn("auth_denied", "reason", "missing_header",
+					"method", r.Method, "path", r.URL.Path)
+				return
+			}
+
+			fields := strings.Fields(h)
+			if len(fields) != 2 || !strings.EqualFold(fields[0], "Bearer") {
+				writeUnauthorized(w, "unauthorized")
+				logger.Warn("auth_denied", "reason", "bad_scheme",
+					"method", r.Method, "path", r.URL.Path)
+				return
+			}
+
+			providedHash := sha256.Sum256([]byte(fields[1]))
+			if subtle.ConstantTimeCompare(providedHash[:], expectedHash[:]) != 1 {
+				writeUnauthorized(w, "unauthorized")
+				logger.Warn("auth_denied", "reason", "mismatch",
+					"method", r.Method, "path", r.URL.Path)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func writeUnauthorized(w http.ResponseWriter, msg string) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("WWW-Authenticate", "Bearer")
+	w.WriteHeader(http.StatusUnauthorized)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}

--- a/internal/server/auth/auth_test.go
+++ b/internal/server/auth/auth_test.go
@@ -1,0 +1,198 @@
+package auth_test
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/northwatchlabs/northwatch/internal/server/auth"
+)
+
+// nextRecorder is a stub next handler that records whether it ran
+// and writes 204 when it does. Tests assert on ran to distinguish
+// "middleware passed through" from "middleware short-circuited".
+type nextRecorder struct{ ran bool }
+
+func (n *nextRecorder) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		n.ran = true
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestBearerTokenNoHeader(t *testing.T) {
+	rec := &nextRecorder{}
+	h := auth.BearerToken("verysecrettoken1234", discardLogger())(rec.handler())
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/incidents", nil))
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rr.Code)
+	}
+	if rec.ran {
+		t.Errorf("next handler should not have run")
+	}
+	if got := rr.Header().Get("WWW-Authenticate"); got != "Bearer" {
+		t.Errorf("WWW-Authenticate = %q, want %q", got, "Bearer")
+	}
+	var body map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body["error"] != "unauthorized" {
+		t.Errorf("body error = %q, want %q", body["error"], "unauthorized")
+	}
+}
+
+func TestBearerTokenBadScheme(t *testing.T) {
+	rec := &nextRecorder{}
+	h := auth.BearerToken("verysecrettoken1234", discardLogger())(rec.handler())
+
+	req := httptest.NewRequest(http.MethodPost, "/incidents", nil)
+	req.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rr.Code)
+	}
+	if rec.ran {
+		t.Errorf("next handler should not have run")
+	}
+}
+
+func TestBearerTokenWrongToken(t *testing.T) {
+	rec := &nextRecorder{}
+	h := auth.BearerToken("verysecrettoken1234", discardLogger())(rec.handler())
+
+	req := httptest.NewRequest(http.MethodPost, "/incidents", nil)
+	req.Header.Set("Authorization", "Bearer wrongtoken9999wrong")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rr.Code)
+	}
+	if rec.ran {
+		t.Errorf("next handler should not have run")
+	}
+}
+
+func TestBearerTokenRightToken(t *testing.T) {
+	rec := &nextRecorder{}
+	h := auth.BearerToken("verysecrettoken1234", discardLogger())(rec.handler())
+
+	req := httptest.NewRequest(http.MethodPost, "/incidents", nil)
+	req.Header.Set("Authorization", "Bearer verysecrettoken1234")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", rr.Code)
+	}
+	if !rec.ran {
+		t.Errorf("next handler should have run")
+	}
+}
+
+func TestBearerTokenCaseInsensitiveScheme(t *testing.T) {
+	rec := &nextRecorder{}
+	h := auth.BearerToken("verysecrettoken1234", discardLogger())(rec.handler())
+
+	req := httptest.NewRequest(http.MethodPost, "/incidents", nil)
+	req.Header.Set("Authorization", "bearer verysecrettoken1234")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204 (scheme is case-insensitive per RFC 6750)", rr.Code)
+	}
+	if !rec.ran {
+		t.Errorf("next handler should have run")
+	}
+}
+
+func TestBearerTokenEmptyExpectedDisablesRoutes(t *testing.T) {
+	rec := &nextRecorder{}
+	h := auth.BearerToken("", discardLogger())(rec.handler())
+
+	req := httptest.NewRequest(http.MethodPost, "/incidents", nil)
+	req.Header.Set("Authorization", "Bearer anytoken")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rr.Code)
+	}
+	if rec.ran {
+		t.Errorf("next handler should not have run when writes are disabled")
+	}
+	var body map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body["error"] != "write endpoints disabled" {
+		t.Errorf("body error = %q, want %q", body["error"], "write endpoints disabled")
+	}
+}
+
+func TestBearerTokenWWWAuthenticateOnEveryFailure(t *testing.T) {
+	cases := []struct {
+		name     string
+		expected string
+		header   string
+	}{
+		{"no header", "verysecrettoken1234", ""},
+		{"bad scheme", "verysecrettoken1234", "Basic abc"},
+		{"wrong token", "verysecrettoken1234", "Bearer wrongtoken9999wrong"},
+		{"writes disabled", "", "Bearer anytoken"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := &nextRecorder{}
+			h := auth.BearerToken(tc.expected, discardLogger())(rec.handler())
+
+			req := httptest.NewRequest(http.MethodPost, "/incidents", nil)
+			if tc.header != "" {
+				req.Header.Set("Authorization", tc.header)
+			}
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, req)
+
+			if got := rr.Header().Get("WWW-Authenticate"); got != "Bearer" {
+				t.Errorf("WWW-Authenticate = %q, want %q", got, "Bearer")
+			}
+			if !strings.HasPrefix(rr.Header().Get("Content-Type"), "application/json") {
+				t.Errorf("content-type = %q, want application/json prefix", rr.Header().Get("Content-Type"))
+			}
+		})
+	}
+}
+
+func TestBearerTokenConstantTimeCompare(t *testing.T) {
+	// Qualitative check: two equal-length wrong tokens both yield
+	// 401 with the same response. Documents intent; the actual
+	// timing property is not testable without instrumentation.
+	rec := &nextRecorder{}
+	h := auth.BearerToken("verysecrettoken1234", discardLogger())(rec.handler())
+
+	for _, tok := range []string{"aaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbb"} {
+		req := httptest.NewRequest(http.MethodPost, "/incidents", nil)
+		req.Header.Set("Authorization", "Bearer "+tok)
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusUnauthorized {
+			t.Errorf("token %q: status = %d, want 401", tok, rr.Code)
+		}
+	}
+}

--- a/internal/server/incidents.go
+++ b/internal/server/incidents.go
@@ -7,7 +7,10 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/go-chi/chi/v5"
+
 	"github.com/northwatchlabs/northwatch/internal/incident"
+	"github.com/northwatchlabs/northwatch/internal/store"
 )
 
 // apiIncident is the JSON wire shape. Kept separate from
@@ -65,10 +68,8 @@ func apiIncidentsHandler(svc *incident.Service, logger *slog.Logger) http.Handle
 	}
 }
 
-// createIncidentHandler serves POST /incidents. NOT registered in
-// server.New in this PR — issue #21 wires it under bearer-token
-// middleware. Exposed via CreateIncidentHandlerForTest so handler
-// tests can invoke it directly via httptest.
+// createIncidentHandler serves POST /incidents. Registered in
+// server.New under the bearer-token middleware.
 func createIncidentHandler(svc *incident.Service, logger *slog.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		dec := json.NewDecoder(r.Body)
@@ -112,10 +113,24 @@ func writeJSONError(w http.ResponseWriter, code int, msg string) {
 	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
 }
 
-// CreateIncidentHandlerForTest returns the POST /incidents handler
-// without registering it on a router. Test-only export to support
-// direct httptest invocation while the production wiring remains in
-// #21. Do not use from production code.
-func CreateIncidentHandlerForTest(svc *incident.Service, logger *slog.Logger) http.HandlerFunc {
-	return createIncidentHandler(svc, logger)
+// resolveIncidentHandler serves POST /incidents/{id}/resolve.
+// Idempotent: 200 on success, including the no-op resolve of an
+// already-resolved incident (response body carries the *original*
+// resolvedAt). 404 if the incident does not exist.
+func resolveIncidentHandler(svc *incident.Service, logger *slog.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		inc, err := svc.ResolveIncident(r.Context(), id)
+		switch {
+		case errors.Is(err, store.ErrNotFound):
+			writeJSONError(w, http.StatusNotFound, "incident not found")
+			return
+		case err != nil:
+			logger.Error("incidents/resolve: failed", "err", err)
+			http.Error(w, "store error", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(toAPIIncident(inc))
+	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/northwatchlabs/northwatch/internal/component"
 	"github.com/northwatchlabs/northwatch/internal/incident"
+	"github.com/northwatchlabs/northwatch/internal/server/auth"
 	"github.com/northwatchlabs/northwatch/internal/store"
 	"github.com/northwatchlabs/northwatch/internal/ui"
 )
@@ -24,9 +25,13 @@ type pageData struct {
 }
 
 // New returns an http.Handler with routes for the status page,
-// healthcheck, and embedded static assets. The store is consulted on
-// every index render.
-func New(logger *slog.Logger, st store.Store) (http.Handler, error) {
+// healthcheck, embedded static assets, and bearer-token-protected
+// write endpoints. The store is consulted on every index render.
+//
+// apiToken gates POST routes. An empty token boots the server with
+// the write side disabled — every POST returns 401. Reads remain
+// public regardless of token state.
+func New(logger *slog.Logger, st store.Store, apiToken string) (http.Handler, error) {
 	tmpl, err := ui.Templates()
 	if err != nil {
 		return nil, err
@@ -52,6 +57,12 @@ func New(logger *slog.Logger, st store.Store) (http.Handler, error) {
 	r.Get("/api/components", apiComponentsHandler(st, logger))
 	r.Get("/api/incidents", apiIncidentsHandler(incSvc, logger))
 	r.Get("/", indexHandler(tmpl, st, logger))
+
+	r.Group(func(r chi.Router) {
+		r.Use(auth.BearerToken(apiToken, logger))
+		r.Post("/incidents", createIncidentHandler(incSvc, logger))
+		r.Post("/incidents/{id}/resolve", resolveIncidentHandler(incSvc, logger))
+	})
 
 	return r, nil
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -18,9 +18,16 @@ import (
 	"github.com/northwatchlabs/northwatch/internal/store"
 )
 
-// newHandler boots an in-memory store, migrates it, optionally seeds
-// components, and returns the wired HTTP handler.
-func newHandler(t *testing.T, seed ...component.Component) http.Handler {
+// testToken is the fixture bearer token used by every write-side
+// test in this file. ≥16 chars so it satisfies the cmd-line
+// validation rule even though tests don't go through cmd parsing.
+const testToken = "test-fixture-token-1234"
+
+// newHandlerWith boots an in-memory store, migrates it, optionally
+// seeds components, and returns the wired HTTP handler + store. The
+// token is passed verbatim into server.New: pass testToken to enable
+// writes, "" to test writes-disabled mode.
+func newHandlerWith(t *testing.T, token string, seed ...component.Component) (http.Handler, *store.SQLite) {
 	t.Helper()
 	ctx := context.Background()
 	st, err := store.OpenSQLite(ctx, ":memory:")
@@ -36,10 +43,19 @@ func newHandler(t *testing.T, seed ...component.Component) http.Handler {
 			t.Fatalf("UpsertComponent: %v", err)
 		}
 	}
-	h, err := server.New(slog.New(slog.NewTextHandler(io.Discard, nil)), st)
+	h, err := server.New(slog.New(slog.NewTextHandler(io.Discard, nil)), st, token)
 	if err != nil {
 		t.Fatalf("server.New: %v", err)
 	}
+	return h, st
+}
+
+// newHandler is the GET-only convenience: token is empty (writes
+// disabled, which GET-only tests never exercise) and the store is
+// discarded.
+func newHandler(t *testing.T, seed ...component.Component) http.Handler {
+	t.Helper()
+	h, _ := newHandlerWith(t, "", seed...)
 	return h
 }
 
@@ -197,7 +213,7 @@ func TestAPIComponents_StoreError(t *testing.T) {
 		t.Fatalf("Migrate: %v", err)
 	}
 	h, err := server.New(slog.New(slog.NewTextHandler(io.Discard, nil)),
-		failingStore{Store: real})
+		failingStore{Store: real}, "")
 	if err != nil {
 		t.Fatalf("server.New: %v", err)
 	}
@@ -210,30 +226,12 @@ func TestAPIComponents_StoreError(t *testing.T) {
 	}
 }
 
-// newHandlerWithStore is like newHandler but also returns the store
-// so tests can seed incidents (which require a store handle rather
-// than going through any *server.Server exported API).
+// newHandlerWithStore returns the GET-only handler + the store for
+// tests that seed incidents directly. Token is empty (writes
+// disabled).
 func newHandlerWithStore(t *testing.T, seed ...component.Component) (http.Handler, *store.SQLite) {
 	t.Helper()
-	ctx := context.Background()
-	st, err := store.OpenSQLite(ctx, ":memory:")
-	if err != nil {
-		t.Fatalf("OpenSQLite: %v", err)
-	}
-	t.Cleanup(func() { _ = st.Close() })
-	if err := st.Migrate(ctx); err != nil {
-		t.Fatalf("Migrate: %v", err)
-	}
-	for _, c := range seed {
-		if err := st.UpsertComponent(ctx, c); err != nil {
-			t.Fatalf("UpsertComponent: %v", err)
-		}
-	}
-	h, err := server.New(slog.New(slog.NewTextHandler(io.Discard, nil)), st)
-	if err != nil {
-		t.Fatalf("server.New: %v", err)
-	}
-	return h, st
+	return newHandlerWith(t, "", seed...)
 }
 
 // seedIncident inserts one active incident + first update directly via
@@ -332,39 +330,24 @@ func TestGetAPIIncidentsCacheControlNoStore(t *testing.T) {
 	}
 }
 
-// newPostHandler builds a createIncidentHandler bound to a fresh
-// in-memory store seeded with the given components. Returns the
-// handler and the store so the test can assert side effects.
-func newPostHandler(t *testing.T, seed ...component.Component) (http.HandlerFunc, *store.SQLite) {
+// postIncident is a small helper that POSTs a create-incident body
+// through the wired router, with the bearer token attached. Returns
+// the recorder so callers can assert on status and body.
+func postIncident(t *testing.T, h http.Handler, body string) *httptest.ResponseRecorder {
 	t.Helper()
-	ctx := context.Background()
-	st, err := store.OpenSQLite(ctx, ":memory:")
-	if err != nil {
-		t.Fatalf("OpenSQLite: %v", err)
-	}
-	t.Cleanup(func() { _ = st.Close() })
-	if err := st.Migrate(ctx); err != nil {
-		t.Fatalf("Migrate: %v", err)
-	}
-	for _, c := range seed {
-		if err := st.UpsertComponent(ctx, c); err != nil {
-			t.Fatalf("seed: %v", err)
-		}
-	}
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	svc := incident.NewService(st, logger)
-	return server.CreateIncidentHandlerForTest(svc, logger), st
+	req := httptest.NewRequest(http.MethodPost, "/incidents", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testToken)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	return rr
 }
 
 func TestCreateIncidentHandlerCreated(t *testing.T) {
-	h, _ := newPostHandler(t, component.Component{
+	h, _ := newHandlerWith(t, testToken, component.Component{
 		Kind: "Deployment", Namespace: "default", Name: "web",
 	})
-	body := strings.NewReader(`{"component":"Deployment/default/web","title":"Pods down"}`)
-	req := httptest.NewRequest(http.MethodPost, "/incidents", body)
-	req.Header.Set("Content-Type", "application/json")
-	rr := httptest.NewRecorder()
-	h.ServeHTTP(rr, req)
+	rr := postIncident(t, h, `{"component":"Deployment/default/web","title":"Pods down"}`)
 
 	if rr.Code != http.StatusCreated {
 		t.Fatalf("status = %d, want 201; body=%s", rr.Code, rr.Body.String())
@@ -388,13 +371,10 @@ func TestCreateIncidentHandlerCreated(t *testing.T) {
 }
 
 func TestCreateIncidentHandlerMissingTitle(t *testing.T) {
-	h, _ := newPostHandler(t, component.Component{
+	h, _ := newHandlerWith(t, testToken, component.Component{
 		Kind: "Deployment", Namespace: "default", Name: "web",
 	})
-	req := httptest.NewRequest(http.MethodPost, "/incidents",
-		strings.NewReader(`{"component":"Deployment/default/web","title":""}`))
-	rr := httptest.NewRecorder()
-	h.ServeHTTP(rr, req)
+	rr := postIncident(t, h, `{"component":"Deployment/default/web","title":""}`)
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", rr.Code)
 	}
@@ -404,11 +384,8 @@ func TestCreateIncidentHandlerMissingTitle(t *testing.T) {
 }
 
 func TestCreateIncidentHandlerMissingComponent(t *testing.T) {
-	h, _ := newPostHandler(t)
-	req := httptest.NewRequest(http.MethodPost, "/incidents",
-		strings.NewReader(`{"title":"oops"}`))
-	rr := httptest.NewRecorder()
-	h.ServeHTTP(rr, req)
+	h, _ := newHandlerWith(t, testToken)
+	rr := postIncident(t, h, `{"title":"oops"}`)
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", rr.Code)
 	}
@@ -418,11 +395,8 @@ func TestCreateIncidentHandlerMissingComponent(t *testing.T) {
 }
 
 func TestCreateIncidentHandlerUnknownComponent(t *testing.T) {
-	h, _ := newPostHandler(t) // no seeded components
-	req := httptest.NewRequest(http.MethodPost, "/incidents",
-		strings.NewReader(`{"component":"Deployment/default/ghost","title":"x"}`))
-	rr := httptest.NewRecorder()
-	h.ServeHTTP(rr, req)
+	h, _ := newHandlerWith(t, testToken)
+	rr := postIncident(t, h, `{"component":"Deployment/default/ghost","title":"x"}`)
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", rr.Code)
 	}
@@ -432,43 +406,201 @@ func TestCreateIncidentHandlerUnknownComponent(t *testing.T) {
 }
 
 func TestCreateIncidentHandlerUnknownJSONField(t *testing.T) {
-	h, _ := newPostHandler(t, component.Component{
+	h, _ := newHandlerWith(t, testToken, component.Component{
 		Kind: "Deployment", Namespace: "default", Name: "web",
 	})
-	req := httptest.NewRequest(http.MethodPost, "/incidents",
-		strings.NewReader(`{"component":"Deployment/default/web","title":"x","mystery":1}`))
-	rr := httptest.NewRecorder()
-	h.ServeHTTP(rr, req)
+	rr := postIncident(t, h, `{"component":"Deployment/default/web","title":"x","mystery":1}`)
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", rr.Code)
 	}
 	if !strings.Contains(rr.Body.String(), "unknown field") {
-		t.Errorf("body = %s, want contains 'unknown field' (decoder error should be surfaced)", rr.Body.String())
+		t.Errorf("body = %s, want contains 'unknown field'", rr.Body.String())
 	}
 }
 
 func TestCreateIncidentHandlerMalformedJSON(t *testing.T) {
-	h, _ := newPostHandler(t)
-	req := httptest.NewRequest(http.MethodPost, "/incidents",
-		strings.NewReader(`{not-json`))
-	rr := httptest.NewRecorder()
-	h.ServeHTTP(rr, req)
+	h, _ := newHandlerWith(t, testToken)
+	rr := postIncident(t, h, `{not-json`)
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", rr.Code)
 	}
 }
 
-func TestPostIncidentsRouteNotRegistered(t *testing.T) {
-	h, _ := newHandlerWithStore(t)
-	rr := httptest.NewRecorder()
+func TestPostIncidentsRequiresAuth(t *testing.T) {
+	h, _ := newHandlerWith(t, testToken, component.Component{
+		Kind: "Deployment", Namespace: "default", Name: "web",
+	})
 	req := httptest.NewRequest(http.MethodPost, "/incidents",
-		strings.NewReader(`{"component":"x","title":"y"}`))
+		strings.NewReader(`{"component":"Deployment/default/web","title":"x"}`))
+	// No Authorization header.
+	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
-	// chi returns 405 Method Not Allowed when a method is missing
-	// on an otherwise-registered path, or 404 when the path is
-	// unregistered. Either confirms the POST route is not wired.
-	if rr.Code != http.StatusNotFound && rr.Code != http.StatusMethodNotAllowed {
-		t.Fatalf("POST /incidents status = %d, want 404 or 405 "+
-			"(route must be deferred to #21)", rr.Code)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rr.Code)
+	}
+}
+
+func TestPostIncidentsWrongToken(t *testing.T) {
+	h, _ := newHandlerWith(t, testToken, component.Component{
+		Kind: "Deployment", Namespace: "default", Name: "web",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/incidents",
+		strings.NewReader(`{"component":"Deployment/default/web","title":"x"}`))
+	req.Header.Set("Authorization", "Bearer wrong-token-9999-bad")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rr.Code)
+	}
+}
+
+func TestWritesDisabledWhenNoToken(t *testing.T) {
+	h, _ := newHandlerWith(t, "", component.Component{
+		Kind: "Deployment", Namespace: "default", Name: "web",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/incidents",
+		strings.NewReader(`{"component":"Deployment/default/web","title":"x"}`))
+	req.Header.Set("Authorization", "Bearer anything")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rr.Code)
+	}
+	if !strings.Contains(rr.Body.String(), "write endpoints disabled") {
+		t.Errorf("body = %s, want contains write endpoints disabled", rr.Body.String())
+	}
+}
+
+func TestGetEndpointsRemainOpenWithoutToken(t *testing.T) {
+	h, _ := newHandlerWith(t, "", component.Component{
+		Kind: "Deployment", Namespace: "default", Name: "web",
+	})
+	for _, path := range []string{"/api/components", "/api/incidents", "/"} {
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, path, nil))
+		if rr.Code != http.StatusOK {
+			t.Errorf("GET %s status = %d, want 200", path, rr.Code)
+		}
+	}
+}
+
+// createIncidentVia posts and returns the created incident ID and
+// the decoded body, failing the test on non-201.
+func createIncidentVia(t *testing.T, h http.Handler, component, title string) (string, map[string]any) {
+	t.Helper()
+	rr := postIncident(t, h,
+		`{"component":"`+component+`","title":"`+title+`"}`)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create: status = %d, want 201; body=%s", rr.Code, rr.Body.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode created: %v", err)
+	}
+	id, _ := got["id"].(string)
+	if id == "" {
+		t.Fatalf("created body has no id: %v", got)
+	}
+	return id, got
+}
+
+func resolveIncident(t *testing.T, h http.Handler, id string, withToken bool) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/incidents/"+id+"/resolve", nil)
+	if withToken {
+		req.Header.Set("Authorization", "Bearer "+testToken)
+	}
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	return rr
+}
+
+func TestPostIncidentsResolveHappyPath(t *testing.T) {
+	h, _ := newHandlerWith(t, testToken, component.Component{
+		Kind: "Deployment", Namespace: "default", Name: "web",
+	})
+	id, _ := createIncidentVia(t, h, "Deployment/default/web", "boom")
+
+	rr := resolveIncident(t, h, id, true)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("resolve status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got["status"] != "resolved" {
+		t.Errorf("status = %v, want resolved", got["status"])
+	}
+	if got["resolvedAt"] == nil {
+		t.Errorf("resolvedAt missing from body")
+	}
+}
+
+func TestPostIncidentsResolveNotFound(t *testing.T) {
+	h, _ := newHandlerWith(t, testToken)
+	rr := resolveIncident(t, h, "01HXNOSUCHINCIDENT00000000", true)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body=%s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "incident not found") {
+		t.Errorf("body = %s, want incident not found", rr.Body.String())
+	}
+}
+
+func TestPostIncidentsResolveIdempotent(t *testing.T) {
+	h, st := newHandlerWith(t, testToken, component.Component{
+		Kind: "Deployment", Namespace: "default", Name: "web",
+	})
+	id, _ := createIncidentVia(t, h, "Deployment/default/web", "boom")
+
+	first := resolveIncident(t, h, id, true)
+	if first.Code != http.StatusOK {
+		t.Fatalf("first resolve status = %d, want 200", first.Code)
+	}
+	var firstBody map[string]any
+	if err := json.Unmarshal(first.Body.Bytes(), &firstBody); err != nil {
+		t.Fatalf("decode first: %v", err)
+	}
+	firstResolved, _ := firstBody["resolvedAt"].(string)
+	if firstResolved == "" {
+		t.Fatalf("first resolvedAt missing")
+	}
+
+	second := resolveIncident(t, h, id, true)
+	if second.Code != http.StatusOK {
+		t.Fatalf("second resolve status = %d, want 200; body=%s",
+			second.Code, second.Body.String())
+	}
+	var secondBody map[string]any
+	if err := json.Unmarshal(second.Body.Bytes(), &secondBody); err != nil {
+		t.Fatalf("decode second: %v", err)
+	}
+	secondResolved, _ := secondBody["resolvedAt"].(string)
+	if secondResolved != firstResolved {
+		t.Errorf("second resolvedAt = %q, want %q (idempotent)",
+			secondResolved, firstResolved)
+	}
+
+	// Only one resolve-update row landed: 1 initial + 1 resolve = 2.
+	var n int
+	if err := st.DB().QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM incident_updates WHERE incident_id = ?`,
+		id).Scan(&n); err != nil {
+		t.Fatalf("count updates: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("incident_updates count = %d, want 2", n)
+	}
+}
+
+func TestPostIncidentsResolveRequiresAuth(t *testing.T) {
+	h, _ := newHandlerWith(t, testToken, component.Component{
+		Kind: "Deployment", Namespace: "default", Name: "web",
+	})
+	id, _ := createIncidentVia(t, h, "Deployment/default/web", "boom")
+	rr := resolveIncident(t, h, id, false)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rr.Code)
 	}
 }

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -512,3 +512,85 @@ func (s *SQLite) ListIncidents(ctx context.Context, includeResolved bool) ([]inc
 	}
 	return out, rows.Err()
 }
+
+const stmtUpdateIncidentResolved = `
+UPDATE incidents SET status = 'resolved', resolved_at = ?
+WHERE id = ?;
+`
+
+// ResolveIncident is the idempotent resolve operation. The
+// transaction holds the write lock across the SELECT-then-UPDATE
+// sequence, so two concurrent callers serialize: the first commits
+// the resolve and inserts an update row; the second observes the
+// already-resolved state and returns it unchanged, without writing
+// a second update row.
+//
+// The inserted incident_updates row's incident_id, created_at, and
+// status are derived from the function's id, resolvedAt, and the
+// resolved status constant respectively — not from a caller-supplied
+// Update — so the timeline row cannot disagree with the incident row.
+func (s *SQLite) ResolveIncident(
+	ctx context.Context,
+	id string,
+	resolvedAt time.Time,
+	updateID string,
+	updateBody string,
+) (incident.Incident, error) {
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return incident.Incident{}, fmt.Errorf("store: acquire conn: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		return incident.Incident{}, fmt.Errorf("store: begin immediate: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(context.Background(), "ROLLBACK")
+		}
+	}()
+
+	row := conn.QueryRowContext(ctx, stmtGetIncident, id)
+	inc, err := scanIncident(row.Scan)
+	if err != nil {
+		// ErrNotFound bubbles unchanged; other errors get wrapped.
+		if errors.Is(err, ErrNotFound) {
+			return incident.Incident{}, ErrNotFound
+		}
+		return incident.Incident{}, fmt.Errorf("store: read incident: %w", err)
+	}
+
+	if inc.ResolvedAt != nil {
+		// Already resolved — no-op. Commit the empty transaction to
+		// release the lock promptly; rollback would also be correct.
+		if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+			return incident.Incident{}, fmt.Errorf("store: commit no-op: %w", err)
+		}
+		committed = true
+		return inc, nil
+	}
+
+	resolvedUnix := resolvedAt.UTC().Unix()
+	if _, err := conn.ExecContext(ctx, stmtUpdateIncidentResolved,
+		resolvedUnix, id,
+	); err != nil {
+		return incident.Incident{}, fmt.Errorf("store: update incident resolved: %w", err)
+	}
+	if _, err := conn.ExecContext(ctx, stmtInsertIncidentUpdate,
+		updateID, id, updateBody, string(incident.StatusResolved), resolvedUnix,
+	); err != nil {
+		return incident.Incident{}, fmt.Errorf("store: insert resolve update: %w", err)
+	}
+
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return incident.Incident{}, fmt.Errorf("store: commit: %w", err)
+	}
+	committed = true
+
+	inc.Status = incident.StatusResolved
+	resolved := time.Unix(resolvedUnix, 0).UTC()
+	inc.ResolvedAt = &resolved
+	return inc, nil
+}

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -982,3 +982,211 @@ func TestListIncidentsOrderedByOpenedAtDesc(t *testing.T) {
 		}
 	}
 }
+
+// seedActiveIncident creates one active incident with one initial
+// update row. Returns the incident ID and the opened-at timestamp.
+func seedActiveIncident(t *testing.T, s *store.SQLite, incID, compID string) (string, time.Time) {
+	t.Helper()
+	ctx := context.Background()
+	opened := time.Unix(1_700_000_000, 0).UTC()
+	inc := incident.Incident{
+		ID: incID, ComponentID: compID,
+		Title: "boom", Status: incident.StatusInvestigating, OpenedAt: opened,
+	}
+	upd := incident.Update{
+		ID: "u-" + incID, IncidentID: incID, Body: "boom",
+		Status: incident.StatusInvestigating, CreatedAt: opened,
+	}
+	if err := s.CreateIncident(ctx, inc, upd); err != nil {
+		t.Fatalf("seed active incident: %v", err)
+	}
+	return incID, opened
+}
+
+// countIncidentUpdates returns the number of incident_updates rows
+// for a given incident_id.
+func countIncidentUpdates(t *testing.T, s *store.SQLite, incID string) int {
+	t.Helper()
+	var n int
+	row := s.DB().QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM incident_updates WHERE incident_id = ?`, incID)
+	if err := row.Scan(&n); err != nil {
+		t.Fatalf("count incident_updates: %v", err)
+	}
+	return n
+}
+
+func TestResolveIncidentSetsResolvedAtAndAppendsUpdate(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedComponent(t, s, component.Component{
+		Kind: "Deployment", Namespace: "default", Name: "web",
+	})
+	incID, _ := seedActiveIncident(t, s,
+		"01HXINC0000000000000000R1", "Deployment/default/web")
+
+	resolvedAt := time.Unix(1_700_001_000, 0).UTC()
+	updateID := "u-resolve-1"
+
+	got, err := s.ResolveIncident(ctx, incID, resolvedAt, updateID, "Incident resolved.")
+	if err != nil {
+		t.Fatalf("ResolveIncident: %v", err)
+	}
+	if got.Status != incident.StatusResolved {
+		t.Errorf("status = %s, want resolved", got.Status)
+	}
+	if got.ResolvedAt == nil || !got.ResolvedAt.Equal(resolvedAt) {
+		t.Errorf("ResolvedAt = %v, want %v", got.ResolvedAt, resolvedAt)
+	}
+
+	persisted, err := s.GetIncident(ctx, incID)
+	if err != nil {
+		t.Fatalf("GetIncident: %v", err)
+	}
+	if persisted.Status != incident.StatusResolved {
+		t.Errorf("persisted status = %s, want resolved", persisted.Status)
+	}
+	if persisted.ResolvedAt == nil || !persisted.ResolvedAt.Equal(resolvedAt) {
+		t.Errorf("persisted ResolvedAt = %v, want %v", persisted.ResolvedAt, resolvedAt)
+	}
+
+	if n := countIncidentUpdates(t, s, incID); n != 2 {
+		t.Errorf("incident_updates count = %d, want 2 (initial + resolve)", n)
+	}
+
+	var body, status string
+	row := s.DB().QueryRowContext(ctx,
+		`SELECT body, status FROM incident_updates WHERE id = ?`, updateID)
+	if err := row.Scan(&body, &status); err != nil {
+		t.Fatalf("scan resolve update: %v", err)
+	}
+	if body != "Incident resolved." || status != string(incident.StatusResolved) {
+		t.Errorf("resolve update = (body=%q, status=%q), want (\"Incident resolved.\", resolved)", body, status)
+	}
+}
+
+func TestResolveIncidentUnknownReturnsErrNotFound(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := s.ResolveIncident(ctx, "ghost", time.Now().UTC(),
+		"u-resolve-x", "Incident resolved.")
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+
+	if n := countIncidentUpdates(t, s, "ghost"); n != 0 {
+		t.Errorf("incident_updates count = %d, want 0", n)
+	}
+}
+
+func TestResolveIncidentAlreadyResolvedIsNoOp(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedComponent(t, s, component.Component{
+		Kind: "Deployment", Namespace: "default", Name: "web",
+	})
+	incID, _ := seedActiveIncident(t, s,
+		"01HXINC0000000000000000R2", "Deployment/default/web")
+
+	firstResolve := time.Unix(1_700_001_000, 0).UTC()
+	if _, err := s.ResolveIncident(ctx, incID, firstResolve,
+		"u-resolve-first", "Incident resolved."); err != nil {
+		t.Fatalf("first resolve: %v", err)
+	}
+
+	secondResolve := time.Unix(1_700_009_999, 0).UTC()
+	secondUpdateID := "u-resolve-second"
+	got, err := s.ResolveIncident(ctx, incID, secondResolve,
+		secondUpdateID, "Incident resolved.")
+	if err != nil {
+		t.Fatalf("second resolve: %v", err)
+	}
+
+	// Returned incident must reflect the *first* resolve.
+	if got.ResolvedAt == nil || !got.ResolvedAt.Equal(firstResolve) {
+		t.Errorf("returned ResolvedAt = %v, want %v (first resolve)", got.ResolvedAt, firstResolve)
+	}
+
+	persisted, err := s.GetIncident(ctx, incID)
+	if err != nil {
+		t.Fatalf("GetIncident: %v", err)
+	}
+	if persisted.ResolvedAt == nil || !persisted.ResolvedAt.Equal(firstResolve) {
+		t.Errorf("persisted ResolvedAt = %v, want %v (unchanged)", persisted.ResolvedAt, firstResolve)
+	}
+
+	// 1 initial + 1 first-resolve = 2 (second resolve must not insert).
+	if n := countIncidentUpdates(t, s, incID); n != 2 {
+		t.Errorf("incident_updates count = %d, want 2 (no-op resolve must not insert)", n)
+	}
+
+	var exists int
+	row := s.DB().QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM incident_updates WHERE id = ?`, secondUpdateID)
+	if err := row.Scan(&exists); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if exists != 0 {
+		t.Errorf("second update ID present in incident_updates; want absent")
+	}
+}
+
+func TestResolveIncidentConcurrent(t *testing.T) {
+	// :memory: is private per-conn under modernc.org/sqlite, so two
+	// goroutines acquiring conns from the pool would see different
+	// databases. A real file shares state across the pool.
+	dbPath := t.TempDir() + "/concurrent.db"
+	ctx := context.Background()
+	s, err := store.OpenSQLite(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("OpenSQLite: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	if err := s.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	seedComponent(t, s, component.Component{
+		Kind: "Deployment", Namespace: "default", Name: "web",
+	})
+	incID, _ := seedActiveIncident(t, s,
+		"01HXINC0000000000000000R3", "Deployment/default/web")
+
+	t1 := time.Unix(1_700_010_000, 0).UTC()
+	t2 := time.Unix(1_700_020_000, 0).UTC()
+
+	type result struct {
+		inc incident.Incident
+		err error
+	}
+	results := make(chan result, 2)
+	go func() {
+		got, err := s.ResolveIncident(ctx, incID, t1, "u-concurrent-1", "Incident resolved.")
+		results <- result{got, err}
+	}()
+	go func() {
+		got, err := s.ResolveIncident(ctx, incID, t2, "u-concurrent-2", "Incident resolved.")
+		results <- result{got, err}
+	}()
+
+	r1 := <-results
+	r2 := <-results
+	if r1.err != nil {
+		t.Errorf("goroutine 1 err: %v", r1.err)
+	}
+	if r2.err != nil {
+		t.Errorf("goroutine 2 err: %v", r2.err)
+	}
+
+	if r1.inc.ResolvedAt == nil || r2.inc.ResolvedAt == nil ||
+		!r1.inc.ResolvedAt.Equal(*r2.inc.ResolvedAt) {
+		t.Errorf("ResolvedAt diverged across concurrent resolvers: %v vs %v",
+			r1.inc.ResolvedAt, r2.inc.ResolvedAt)
+	}
+
+	// 1 initial + exactly 1 resolve = 2.
+	if n := countIncidentUpdates(t, s, incID); n != 2 {
+		t.Errorf("incident_updates count = %d, want 2 (one resolve only)", n)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/northwatchlabs/northwatch/internal/component"
 	"github.com/northwatchlabs/northwatch/internal/incident"
@@ -124,4 +125,33 @@ type Store interface {
 	// When includeResolved is false, rows with resolved_at IS NOT
 	// NULL are excluded.
 	ListIncidents(ctx context.Context, includeResolved bool) ([]incident.Incident, error)
+
+	// ResolveIncident marks an incident resolved in a single
+	// BEGIN IMMEDIATE transaction. Idempotent at the boundary:
+	//
+	//   - row missing → ErrNotFound, nothing written.
+	//   - row already resolved → no writes; returns the existing
+	//     incident with its original resolved_at. updateID and
+	//     updateBody are unused on this path.
+	//   - row active → UPDATE incidents (status='resolved',
+	//     resolved_at) and INSERT a new incident_updates row with
+	//     (id=updateID, incident_id=id, body=updateBody,
+	//     status='resolved', created_at=resolvedAt), then return
+	//     the updated incident.
+	//
+	// The store derives incident_id, created_at, and status from
+	// the resolve action itself rather than accepting them as
+	// caller-supplied fields — that eliminates a class of bug
+	// where the timeline row could end up inconsistent with the
+	// incident row it describes.
+	//
+	// The transaction's write lock serializes concurrent resolvers,
+	// so two callers cannot disagree about the post-state.
+	ResolveIncident(
+		ctx context.Context,
+		id string,
+		resolvedAt time.Time,
+		updateID string,
+		updateBody string,
+	) (incident.Incident, error)
 }

--- a/internal/watcher/deployment_test.go
+++ b/internal/watcher/deployment_test.go
@@ -76,6 +76,9 @@ func (s *recordStore) GetActiveIncident(context.Context) (incident.Incident, err
 func (s *recordStore) ListIncidents(context.Context, bool) ([]incident.Incident, error) {
 	return nil, nil
 }
+func (s *recordStore) ResolveIncident(context.Context, string, time.Time, string, string) (incident.Incident, error) {
+	return incident.Incident{}, store.ErrNotFound
+}
 
 func (s *recordStore) count() int {
 	s.mu.Lock()


### PR DESCRIPTION
## Summary
- Gate `POST /incidents` and `POST /incidents/{id}/resolve` behind a shared bearer token, configured via `--api-token` flag / `NORTHWATCH_API_TOKEN` env. Constant-time compare; token value is never logged.
- Empty token boots writes-disabled — every POST returns 401 with `{"error":"write endpoints disabled"}`. `GET` routes stay public regardless.
- Boot fails closed when a token is configured but shorter than 16 characters.
- Resolve uses PUT-like 200-idempotent semantics: a second resolve on an already-resolved incident returns 200 with the *original* `resolvedAt` and writes no extra rows. 404 only when the incident does not exist.
- Resolve is a single `BEGIN IMMEDIATE` transaction that updates the incident row AND appends a `resolved` `incident_updates` row, so the timeline stays consistent with the incident state and concurrent resolvers serialize cleanly.

Closes #21

## Test plan
- [x] `go build ./...` succeeds.
- [x] `go test ./...` passes (auth, store, service, server, watcher).
- [x] `go vet ./...` clean.
- [x] Manual: `NORTHWATCH_API_TOKEN=verysecrettoken1234 ./northwatch serve --db /tmp/n.db` — no-token POST returns 401; with-token POST returns 201.
- [x] Manual: resolve twice — both return 200 with the same `resolvedAt`; only one `incident_updates` row with status `resolved` lands.
- [x] Manual: resolve unknown ID returns 404.
- [x] Manual: boot with `NORTHWATCH_API_TOKEN=short` refuses to start (exit 1, `api token too short` log).
- [x] Manual: boot with no token logs `API write endpoints disabled` warning and 401s every POST.