### PR TITLE
Render active-incident banner with HTMX live updates

### DIFF
--- a/cmd/northwatch/main.go
+++ b/cmd/northwatch/main.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -69,6 +70,7 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "  --api-token        Bearer token for write endpoints (>=16 chars).")
 	fmt.Fprintln(os.Stderr, "                     Reads NORTHWATCH_API_TOKEN env when unset.")
 	fmt.Fprintln(os.Stderr, "                     Empty disables writes (POSTs return 401).")
+	fmt.Fprintln(os.Stderr, "  --poll-seconds     HTMX polling interval in seconds (default 5)")
 }
 
 func serveCmd(args []string) int {
@@ -93,6 +95,9 @@ func serveCmd(args []string) int {
 	apiToken := fs.String("api-token",
 		envOr("NORTHWATCH_API_TOKEN", ""),
 		"Bearer token gating POST endpoints (>=16 chars). Empty disables writes.")
+	pollSeconds := fs.Int("poll-seconds",
+		envOrInt("NORTHWATCH_POLL_SECONDS", 5),
+		"HTMX polling interval in seconds (>=1)")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return 0
@@ -114,6 +119,11 @@ func serveCmd(args []string) int {
 		return 1
 	default:
 		logger.Info("api token configured")
+	}
+
+	if *pollSeconds < 1 {
+		logger.Error("poll-seconds must be >= 1", "got", *pollSeconds)
+		return 1
 	}
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
@@ -141,7 +151,7 @@ func serveCmd(args []string) int {
 		return 1
 	}
 
-	h, err := server.New(logger, st, *apiToken)
+	h, err := server.New(logger, st, *apiToken, *pollSeconds)
 	if err != nil {
 		logger.Error("server init failed", "err", err)
 		return 1
@@ -251,6 +261,22 @@ func envOrBool(key string, def bool) bool {
 	default:
 		return false
 	}
+}
+
+// envOrInt reads an int env var. Unset, empty, or non-numeric values
+// fall back to def. Negative values are passed through — callers
+// are responsible for range validation (e.g., serveCmd rejects
+// poll-seconds < 1).
+func envOrInt(key string, def int) int {
+	v, ok := os.LookupEnv(key)
+	if !ok || v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return def
+	}
+	return n
 }
 
 // runConfigSync loads configPath, translates Specs into ComponentSpecs,

--- a/cmd/northwatch/main_test.go
+++ b/cmd/northwatch/main_test.go
@@ -243,3 +243,61 @@ func TestServeCmd_NoClusterShortCircuit(t *testing.T) {
 		t.Fatal("bad kubeconfig: got nil err, want error")
 	}
 }
+
+func TestEnvOrInt(t *testing.T) {
+	cases := []struct {
+		name string
+		val  string
+		set  bool
+		def  int
+		want int
+	}{
+		{name: "valid positive", val: "10", set: true, def: 5, want: 10},
+		{name: "valid zero", val: "0", set: true, def: 5, want: 0},
+		{name: "negative", val: "-3", set: true, def: 5, want: -3},
+		{name: "garbage falls back", val: "five", set: true, def: 5, want: 5},
+		{name: "empty falls back", val: "", set: true, def: 7, want: 7},
+		{name: "unset falls back", val: "", set: false, def: 7, want: 7},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			const key = "NW_TEST_ENVORINT"
+			if tc.set {
+				t.Setenv(key, tc.val)
+			} else {
+				t.Setenv(key, "ignored")
+				if err := os.Unsetenv(key); err != nil {
+					t.Fatalf("Unsetenv: %v", err)
+				}
+			}
+			if got := envOrInt(key, tc.def); got != tc.want {
+				t.Errorf("envOrInt(%q, %d) [val=%q] = %d, want %d", key, tc.def, tc.val, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestServeCmd_PollSecondsValidation(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		val  string
+		want int // expected exit code
+	}{
+		{name: "zero rejected", val: "0", want: 1},
+		{name: "negative rejected", val: "-5", want: 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			code := serveCmd([]string{
+				"--no-cluster",
+				"--db", filepath.Join(t.TempDir(), "nw.db"),
+				"--config", writeConfig(t, cfgAB),
+				"--poll-seconds", tc.val,
+			})
+			if code != tc.want {
+				t.Errorf("serveCmd exit = %d, want %d", code, tc.want)
+			}
+		})
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3,7 +3,9 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"html/template"
 	"log/slog"
 	"net/http"
@@ -20,8 +22,11 @@ import (
 )
 
 type pageData struct {
-	Title      string
-	Components []component.Component
+	Title          string
+	Components     []component.Component
+	ActiveIncident *incident.Incident
+	BannerState    string // "incident" | "degraded" | "operational"
+	PollSeconds    int
 }
 
 // New returns an http.Handler with routes for the status page,
@@ -31,7 +36,7 @@ type pageData struct {
 // apiToken gates POST routes. An empty token boots the server with
 // the write side disabled — every POST returns 401. Reads remain
 // public regardless of token state.
-func New(logger *slog.Logger, st store.Store, apiToken string) (http.Handler, error) {
+func New(logger *slog.Logger, st store.Store, apiToken string, pollSeconds int) (http.Handler, error) {
 	tmpl, err := ui.Templates()
 	if err != nil {
 		return nil, err
@@ -56,7 +61,8 @@ func New(logger *slog.Logger, st store.Store, apiToken string) (http.Handler, er
 	r.Handle("/static/*", http.StripPrefix("/static/", http.FileServerFS(staticFS)))
 	r.Get("/api/components", apiComponentsHandler(st, logger))
 	r.Get("/api/incidents", apiIncidentsHandler(incSvc, logger))
-	r.Get("/", indexHandler(tmpl, st, logger))
+	r.Get("/api/status", statusSectionHandler(tmpl, st, incSvc, pollSeconds, logger))
+	r.Get("/", indexHandler(tmpl, st, incSvc, pollSeconds, logger))
 
 	r.Group(func(r chi.Router) {
 		r.Use(auth.BearerToken(apiToken, logger))
@@ -67,20 +73,13 @@ func New(logger *slog.Logger, st store.Store, apiToken string) (http.Handler, er
 	return r, nil
 }
 
-func indexHandler(tmpl *template.Template, st store.Store, logger *slog.Logger) http.HandlerFunc {
+func indexHandler(tmpl *template.Template, st store.Store, incSvc *incident.Service, pollSeconds int, logger *slog.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		comps, err := st.ListComponents(r.Context())
+		data, err := loadPageData(r.Context(), st, incSvc, pollSeconds)
 		if err != nil {
-			logger.Error("index: ListComponents failed", "err", err)
+			logger.Error("index: loadPageData failed", "err", err)
 			http.Error(w, "store error", http.StatusInternalServerError)
 			return
-		}
-		data := pageData{
-			// Title stays static for v0.1. A future PR derives it from
-			// component statuses (e.g. "Service Degraded" when any
-			// component is non-operational).
-			Title:      "All Systems Operational",
-			Components: comps,
 		}
 		var buf bytes.Buffer
 		if err := tmpl.ExecuteTemplate(&buf, "layout", data); err != nil {
@@ -90,6 +89,70 @@ func indexHandler(tmpl *template.Template, st store.Store, logger *slog.Logger) 
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		_, _ = buf.WriteTo(w)
 	}
+}
+
+// statusSectionHandler renders only the status_section partial,
+// used by HTMX outerHTML polling. The response must include the
+// #status wrapper with the same hx-* attributes the index page
+// uses, otherwise polling stops after the first swap.
+func statusSectionHandler(tmpl *template.Template, st store.Store, incSvc *incident.Service, pollSeconds int, logger *slog.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		data, err := loadPageData(r.Context(), st, incSvc, pollSeconds)
+		if err != nil {
+			logger.Error("api/status: loadPageData failed", "err", err)
+			http.Error(w, "store error", http.StatusInternalServerError)
+			return
+		}
+		var buf bytes.Buffer
+		if err := tmpl.ExecuteTemplate(&buf, "status_section", data); err != nil {
+			logger.Error("api/status: render failed", "err", err)
+			http.Error(w, "render error", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("Cache-Control", "no-store")
+		_, _ = buf.WriteTo(w)
+	}
+}
+
+// loadPageData fetches the components + active incident from the
+// store and computes the banner state. ErrNotFound on the incident
+// lookup is treated as "no active incident" and is not an error;
+// every other error propagates. The returned pageData is ready to
+// hand to either the full layout or the status_section partial.
+func loadPageData(ctx context.Context, st store.Store, incSvc *incident.Service, pollSeconds int) (pageData, error) {
+	comps, err := st.ListComponents(ctx)
+	if err != nil {
+		return pageData{}, err
+	}
+	var active *incident.Incident
+	inc, err := incSvc.GetActiveIncident(ctx)
+	switch {
+	case errors.Is(err, incident.ErrNotFound):
+		// no active incident
+	case err != nil:
+		return pageData{}, err
+	default:
+		active = &inc
+	}
+	state := "operational"
+	if active != nil {
+		state = "incident"
+	} else {
+		for _, c := range comps {
+			if c.Status == component.StatusDegraded || c.Status == component.StatusDown {
+				state = "degraded"
+				break
+			}
+		}
+	}
+	return pageData{
+		Title:          "NorthWatch Status",
+		Components:     comps,
+		ActiveIncident: active,
+		BannerState:    state,
+		PollSeconds:    pollSeconds,
+	}, nil
 }
 
 // apiComponent is the JSON wire shape for components. Kept separate

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -43,7 +43,7 @@ func newHandlerWith(t *testing.T, token string, seed ...component.Component) (ht
 			t.Fatalf("UpsertComponent: %v", err)
 		}
 	}
-	h, err := server.New(slog.New(slog.NewTextHandler(io.Discard, nil)), st, token)
+	h, err := server.New(slog.New(slog.NewTextHandler(io.Discard, nil)), st, token, 5)
 	if err != nil {
 		t.Fatalf("server.New: %v", err)
 	}
@@ -213,7 +213,7 @@ func TestAPIComponents_StoreError(t *testing.T) {
 		t.Fatalf("Migrate: %v", err)
 	}
 	h, err := server.New(slog.New(slog.NewTextHandler(io.Discard, nil)),
-		failingStore{Store: real}, "")
+		failingStore{Store: real}, "", 5)
 	if err != nil {
 		t.Fatalf("server.New: %v", err)
 	}
@@ -602,5 +602,128 @@ func TestPostIncidentsResolveRequiresAuth(t *testing.T) {
 	rr := resolveIncident(t, h, id, false)
 	if rr.Code != http.StatusUnauthorized {
 		t.Fatalf("status = %d, want 401", rr.Code)
+	}
+}
+
+func TestIndex_BannerOperational(t *testing.T) {
+	t.Parallel()
+	h := newHandler(t,
+		component.Component{Kind: "Deployment", Namespace: "default", Name: "a", DisplayName: "A", Status: component.StatusOperational},
+	)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	h.ServeHTTP(rr, req)
+	body := rr.Body.String()
+	if !strings.Contains(body, "All Systems Operational") {
+		t.Errorf("missing operational banner; body=%s", body)
+	}
+	if strings.Contains(body, "Some Systems Degraded") {
+		t.Errorf("operational state should not render degraded banner")
+	}
+}
+
+func TestIndex_BannerDegradedWhenComponentDown(t *testing.T) {
+	t.Parallel()
+	h := newHandler(t,
+		component.Component{Kind: "Deployment", Namespace: "default", Name: "a", DisplayName: "A", Status: component.StatusOperational},
+		component.Component{Kind: "Deployment", Namespace: "default", Name: "b", DisplayName: "B", Status: component.StatusDown},
+	)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	h.ServeHTTP(rr, req)
+	body := rr.Body.String()
+	if !strings.Contains(body, "Some Systems Degraded") {
+		t.Errorf("missing degraded banner; body=%s", body)
+	}
+	if strings.Contains(body, "All Systems Operational") {
+		t.Errorf("degraded state should not render operational banner")
+	}
+}
+
+func TestIndex_BannerIncidentTakesPriority(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st, err := store.OpenSQLite(ctx, ":memory:")
+	if err != nil {
+		t.Fatalf("OpenSQLite: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	comp := component.Component{Kind: "Deployment", Namespace: "default", Name: "a", DisplayName: "A", Status: component.StatusDown}
+	if err := st.UpsertComponent(ctx, comp); err != nil {
+		t.Fatalf("UpsertComponent: %v", err)
+	}
+	incSvc := incident.NewService(st, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if _, err := incSvc.CreateIncident(ctx, comp.ID(), "Demo outage"); err != nil {
+		t.Fatalf("CreateIncident: %v", err)
+	}
+	h, err := server.New(slog.New(slog.NewTextHandler(io.Discard, nil)), st, "", 5)
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	h.ServeHTTP(rr, req)
+	body := rr.Body.String()
+	if !strings.Contains(body, "Demo outage") {
+		t.Errorf("missing incident title; body=%s", body)
+	}
+	if strings.Contains(body, "Some Systems Degraded") {
+		t.Errorf("incident state should not render degraded banner even when components are down")
+	}
+	if strings.Contains(body, "All Systems Operational") {
+		t.Errorf("incident state should not render operational banner")
+	}
+}
+
+func TestApiStatus_PartialIncludesPollingAttrs(t *testing.T) {
+	t.Parallel()
+	h := newHandler(t,
+		component.Component{Kind: "Deployment", Namespace: "default", Name: "a", DisplayName: "A", Status: component.StatusOperational},
+	)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status code = %d, want 200", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Errorf("Content-Type = %q, want text/html", ct)
+	}
+	if cc := rr.Header().Get("Cache-Control"); cc != "no-store" {
+		t.Errorf("Cache-Control = %q, want no-store", cc)
+	}
+	body := rr.Body.String()
+	wants := []string{
+		`id="status"`,
+		`hx-get="/api/status"`,
+		`hx-trigger="every 5s"`,
+		`hx-swap="outerHTML"`,
+		`All Systems Operational`,
+	}
+	for _, w := range wants {
+		if !strings.Contains(body, w) {
+			t.Errorf("partial missing %q; body=%s", w, body)
+		}
+	}
+	for _, banned := range []string{"<html", "<body", "<!DOCTYPE"} {
+		if strings.Contains(body, banned) {
+			t.Errorf("partial should not contain %q; body=%s", banned, body)
+		}
+	}
+}
+
+func TestApiStatus_RendersDegradedWhenComponentDown(t *testing.T) {
+	t.Parallel()
+	h := newHandler(t,
+		component.Component{Kind: "Deployment", Namespace: "default", Name: "a", DisplayName: "A", Status: component.StatusDown},
+	)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+	h.ServeHTTP(rr, req)
+	if !strings.Contains(rr.Body.String(), "Some Systems Degraded") {
+		t.Errorf("partial missing degraded banner; body=%s", rr.Body.String())
 	}
 }

--- a/internal/ui/templates/_banner.html
+++ b/internal/ui/templates/_banner.html
@@ -1,1 +1,21 @@
-{{define "banner"}}{{end}}
+{{define "banner"}}
+{{if eq .BannerState "incident"}}
+<div class="rounded-lg border border-red-200 bg-red-50 p-4 flex items-center gap-3">
+  <span class="h-2.5 w-2.5 rounded-full bg-red-500"></span>
+  <div>
+    <h2 class="font-medium text-red-900">{{.ActiveIncident.Title}}</h2>
+    <p class="text-sm text-red-700 capitalize">{{.ActiveIncident.Status}}</p>
+  </div>
+</div>
+{{else if eq .BannerState "degraded"}}
+<div class="rounded-lg border border-yellow-200 bg-yellow-50 p-4 flex items-center gap-3">
+  <span class="h-2.5 w-2.5 rounded-full bg-yellow-500"></span>
+  <h2 class="font-medium text-yellow-900">Some Systems Degraded</h2>
+</div>
+{{else}}
+<div class="rounded-lg border border-green-200 bg-green-50 p-4 flex items-center gap-3">
+  <span class="h-2.5 w-2.5 rounded-full bg-green-500"></span>
+  <h2 class="font-medium text-green-900">All Systems Operational</h2>
+</div>
+{{end}}
+{{end}}

--- a/internal/ui/templates/_layout.html
+++ b/internal/ui/templates/_layout.html
@@ -10,10 +10,7 @@
 <body class="bg-gray-50 text-gray-900 min-h-screen">
   {{template "header" .}}
   <main class="max-w-3xl mx-auto px-4 py-8">
-    {{template "banner" .}}
-    <section class="mt-6 space-y-3">
-      {{range .Components}}{{template "card" .}}{{end}}
-    </section>
+    {{template "status_section" .}}
   </main>
 </body>
 </html>

--- a/internal/ui/templates/_status_section.html
+++ b/internal/ui/templates/_status_section.html
@@ -1,0 +1,11 @@
+{{define "status_section"}}
+<div id="status"
+     hx-get="/api/status"
+     hx-trigger="every {{.PollSeconds}}s"
+     hx-swap="outerHTML">
+  {{template "banner" .}}
+  <section class="mt-6 space-y-3">
+    {{range .Components}}{{template "card" .}}{{end}}
+  </section>
+</div>
+{{end}}


### PR DESCRIPTION
## Summary
- Adds `GET /api/status` returning a polling partial (banner + cards) that HTMX swaps into the index page every N seconds. Polling interval is configurable via a new `--poll-seconds` flag (default 5).
- Banner is a three-state machine keyed on a precomputed `BannerState` string: **red** incident (incident wins over component health), **yellow** degraded (any component down/degraded), **green** operational. A new `loadPageData` helper centralizes the fetch + state computation and is shared between `/` and `/api/status`, so the full page and the partial cannot drift.
- Small deviation from the spec literal: `pageData.Title` is now `"NorthWatch Status"` (static HTML `<title>`), not `"All Systems Operational"`. The banner's visible text comes from the template branches; keeping the old literal in `Title` was a footgun once `BannerState` carried the live signal.

Closes #22

## Test plan
- [x] `go test ./...` passes (envOrInt, --poll-seconds validation, three banner states on `GET /`, partial-response shape + no-store header on `GET /api/status`, incident precedence test)
- [x] Open `/` in browser, leave it open
- [x] Forcing a component to `down` (sqlite3 UPDATE; equivalent to `kubectl scale deploy nginx --replicas=0`) flips the banner to yellow within ~5s without refresh
- [x] `curl POST /incidents` flips banner to red within ~5s
- [x] `curl POST /incidents/:id/resolve` clears the red banner; falls back to yellow (component still down) — proves aggregate state respected after resolve
- [x] Restoring component to `operational` returns banner to green within ~5s
- [x] No flicker / layout shift on `outerHTML` swaps