### PR TITLE
Watch ArgoCD Applications and reconcile component status

### DIFF
--- a/cmd/northwatch/main.go
+++ b/cmd/northwatch/main.go
@@ -167,10 +167,10 @@ func serveCmd(args []string) int {
 	// goroutine. Clean shutdowns (Start returning nil after
 	// ctx.Done) are NOT forwarded: an erroneous nil send could race
 	// the <-ctx.Done() arm below and let serveCmd return without
-	// calling srv.Shutdown. Sized for both watchers plus the HTTP
+	// calling srv.Shutdown. Sized for all watchers plus the HTTP
 	// server so a real failure can't block its sender during the
 	// shutdown window.
-	errCh := make(chan error, 3)
+	errCh := make(chan error, 4)
 	go func() {
 		logger.Info("listening", "addr", srv.Addr, "db", *dbPath)
 		errCh <- srv.ListenAndServe()
@@ -185,6 +185,13 @@ func serveCmd(args []string) int {
 		if hrWatcher := buildHelmReleaseWatcher(ctx, kc, st, cfg.Components, logger); hrWatcher != nil {
 			go func() {
 				if err := hrWatcher.Start(ctx); err != nil {
+					errCh <- err
+				}
+			}()
+		}
+		if appWatcher := buildApplicationWatcher(ctx, kc, st, cfg.Components, logger); appWatcher != nil {
+			go func() {
+				if err := appWatcher.Start(ctx); err != nil {
 					errCh <- err
 				}
 			}()
@@ -386,6 +393,36 @@ func buildHelmReleaseWatcher(
 		return nil
 	}
 	return watcher.NewHelmReleaseWatcher(dyn, st, specs, logger)
+}
+
+// buildApplicationWatcher probes for the ArgoCD Application CRD and
+// constructs the watcher only when it's present. Returns nil when
+// the CRD is missing — the cluster just doesn't run ArgoCD, which is
+// expected on non-GitOps clusters or Flux-only setups. A probe error
+// is logged but otherwise treated as "absent" so a transient
+// discovery failure doesn't take serve down.
+func buildApplicationWatcher(
+	ctx context.Context,
+	kc *watcher.Client,
+	st store.Store,
+	specs []config.Spec,
+	logger *slog.Logger,
+) *watcher.ApplicationWatcher {
+	present, err := watcher.ApplicationCRDPresent(ctx, kc.Config)
+	if err != nil {
+		logger.Warn("application CRD probe failed; skipping watcher", "err", err)
+		return nil
+	}
+	if !present {
+		logger.Info("ArgoCD CRDs not present, skipping application watcher")
+		return nil
+	}
+	dyn, err := dynamic.NewForConfig(kc.Config)
+	if err != nil {
+		logger.Warn("dynamic client init failed; skipping application watcher", "err", err)
+		return nil
+	}
+	return watcher.NewApplicationWatcher(dyn, st, specs, logger)
 }
 
 func normalizeAddr(addr string) string {

--- a/internal/watcher/application.go
+++ b/internal/watcher/application.go
@@ -1,0 +1,311 @@
+package watcher
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/northwatchlabs/northwatch/internal/component"
+	"github.com/northwatchlabs/northwatch/internal/config"
+	"github.com/northwatchlabs/northwatch/internal/store"
+)
+
+// ApplicationGVR is the dynamic GroupVersionResource for ArgoCD's
+// argoproj.io/v1alpha1 Application custom resource.
+var ApplicationGVR = schema.GroupVersionResource{
+	Group:    "argoproj.io",
+	Version:  "v1alpha1",
+	Resource: "applications",
+}
+
+// ApplicationCRDPresent returns true when the ArgoCD Application
+// CRD (argoproj.io/v1alpha1.applications) is served by the cluster.
+// Use to gate watcher construction so clusters without ArgoCD boot
+// cleanly instead of failing the informer sync on a missing CRD.
+//
+// The probe checks the resource list for ApplicationGVR.GroupVersion,
+// not just the group/version's presence. That distinction matters:
+// argoproj.io/v1alpha1 is shared by Argo CD, Argo Rollouts, and Argo
+// Events, so a Rollouts-only cluster has the group/version registered
+// without any `applications` resource. A group-level probe would say
+// "present" and the informer would then fail to sync.
+//
+// A copied rest.Config caps discovery at pingTimeout so a stalled
+// endpoint can't hang serve startup or SIGTERM handling, and the
+// in-flight request is raced against ctx.Done() via a goroutine in
+// applicationCRDPresentVia.
+func ApplicationCRDPresent(ctx context.Context, cfg *rest.Config) (bool, error) {
+	probeCfg := rest.CopyConfig(cfg)
+	probeCfg.Timeout = pingTimeout
+
+	disc, err := discovery.NewDiscoveryClientForConfig(probeCfg)
+	if err != nil {
+		return false, fmt.Errorf("build discovery client: %w", err)
+	}
+	return applicationCRDPresentVia(ctx, disc)
+}
+
+// applicationResourceDiscovery is the small surface
+// applicationCRDPresentVia needs — narrower than
+// discovery.DiscoveryInterface so tests can drive it with a tiny stub.
+type applicationResourceDiscovery interface {
+	ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error)
+}
+
+// applicationCRDPresentVia is the testable seam. A NotFound from
+// ServerResourcesForGroupVersion means the group/version is not
+// served at all (the common non-ArgoCD, non-Rollouts cluster) and is
+// treated as a clean "absent" result rather than a probe failure.
+func applicationCRDPresentVia(ctx context.Context, disc applicationResourceDiscovery) (bool, error) {
+	type result struct {
+		list *metav1.APIResourceList
+		err  error
+	}
+	resultCh := make(chan result, 1)
+	gv := ApplicationGVR.GroupVersion().String()
+	go func() {
+		list, err := disc.ServerResourcesForGroupVersion(gv)
+		resultCh <- result{list: list, err: err}
+	}()
+
+	var list *metav1.APIResourceList
+	select {
+	case <-ctx.Done():
+		return false, fmt.Errorf("application CRD probe cancelled: %w", ctx.Err())
+	case r := <-resultCh:
+		if r.err != nil {
+			if apierrors.IsNotFound(r.err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("list server resources for %s: %w", gv, r.err)
+		}
+		list = r.list
+	}
+
+	for _, res := range list.APIResources {
+		if res.Name == ApplicationGVR.Resource {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// ApplicationWatcher watches ArgoCD Application events for the
+// configured component set and reconciles status from
+// status.health.status. Only Applications whose (namespace, name)
+// appears in the configured set produce store writes; all others are
+// ignored.
+//
+// Status mapping (see computeApplicationStatus):
+//   - Healthy                  → operational
+//   - Progressing              → degraded
+//   - Degraded, Missing        → down
+//   - Unknown                  → unknown
+//   - Suspended                → preserve previous (no upsert)
+//   - field missing            → unknown (initial state)
+//   - unrecognized             → unknown (forward-compat)
+//
+// Only Suspended preserves the previously recorded status: it's an
+// intentional operator action ("I paused syncing"), and flipping the
+// status page on that signal would be noise. Unknown is the opposite
+// — it means ArgoCD lost the signal — so we surface it as `unknown`
+// rather than silently holding a stale `operational`. Same logic for
+// future unrecognized health values: never lie about state we don't
+// have.
+//
+// In-cluster RBAC: needs get, list, watch on
+// argoproj.io/v1alpha1/applications. The Helm chart (#24) will ship
+// the appropriate ClusterRole.
+type ApplicationWatcher struct {
+	client  dynamic.Interface
+	store   store.Store
+	watched map[types.NamespacedName]config.Spec
+	logger  *slog.Logger
+
+	mu       sync.Mutex
+	lastSeen map[types.NamespacedName]component.Status
+
+	syncedCh   chan struct{}
+	syncedOnce sync.Once
+}
+
+// NewApplicationWatcher mirrors NewHelmReleaseWatcher: it filters
+// specs to Kind == "Application" and builds the lookup map. An empty
+// specs slice is valid — the watcher runs but writes nothing.
+func NewApplicationWatcher(
+	client dynamic.Interface,
+	st store.Store,
+	specs []config.Spec,
+	logger *slog.Logger,
+) *ApplicationWatcher {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	watched := make(map[types.NamespacedName]config.Spec)
+	for _, s := range specs {
+		if s.Kind != "Application" {
+			continue
+		}
+		key := types.NamespacedName{Namespace: s.Namespace, Name: s.Name}
+		watched[key] = s
+	}
+	return &ApplicationWatcher{
+		client:   client,
+		store:    st,
+		watched:  watched,
+		logger:   logger.With("watcher", "application"),
+		lastSeen: make(map[types.NamespacedName]component.Status),
+		syncedCh: make(chan struct{}),
+	}
+}
+
+// Synced returns a channel that is closed once the watcher's informer
+// cache has finished its initial list/watch sync.
+func (w *ApplicationWatcher) Synced() <-chan struct{} {
+	return w.syncedCh
+}
+
+// Start runs the dynamic informer until ctx is cancelled. Blocks; the
+// caller is expected to launch it in its own goroutine.
+func (w *ApplicationWatcher) Start(ctx context.Context) error {
+	factory := dynamicinformer.NewDynamicSharedInformerFactory(w.client, 0)
+	informer := factory.ForResource(ApplicationGVR).Informer()
+
+	if _, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			u, ok := obj.(*unstructured.Unstructured)
+			if !ok {
+				return
+			}
+			w.handle(ctx, u)
+		},
+		UpdateFunc: func(_, newObj interface{}) {
+			u, ok := newObj.(*unstructured.Unstructured)
+			if !ok {
+				return
+			}
+			w.handle(ctx, u)
+		},
+		DeleteFunc: func(_ interface{}) {
+			// Same semantics as the other watchers: the last status
+			// sticks; we don't clear lastSeen or write a recovery.
+		},
+	}); err != nil {
+		return fmt.Errorf("watcher: add event handler: %w", err)
+	}
+
+	factory.Start(ctx.Done())
+	if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
+		if ctx.Err() != nil {
+			return nil
+		}
+		return errors.New("watcher: application cache sync failed")
+	}
+	w.syncedOnce.Do(func() { close(w.syncedCh) })
+	w.logger.Info("synced", "watched", len(w.watched))
+
+	<-ctx.Done()
+	return nil
+}
+
+func (w *ApplicationWatcher) handle(ctx context.Context, u *unstructured.Unstructured) {
+	key := types.NamespacedName{Namespace: u.GetNamespace(), Name: u.GetName()}
+	spec, ok := w.watched[key]
+	if !ok {
+		return
+	}
+
+	status, ok := computeApplicationStatus(u)
+	if !ok {
+		// Suspended: preserve whatever status is already recorded.
+		// Leave lastSeen alone so the next real transition is still
+		// observed.
+		return
+	}
+
+	w.mu.Lock()
+	prev, seen := w.lastSeen[key]
+	if seen && prev == status {
+		w.mu.Unlock()
+		return
+	}
+	w.lastSeen[key] = status
+	w.mu.Unlock()
+
+	c := component.Component{
+		Kind:        "Application",
+		Namespace:   spec.Namespace,
+		Name:        spec.Name,
+		DisplayName: displayNameOrName(spec),
+		Status:      status,
+	}
+	if err := w.store.UpsertComponent(ctx, c); err != nil {
+		w.logger.Error("upsert failed",
+			"err", err,
+			"id", c.ID(),
+			"status", string(status),
+		)
+		w.mu.Lock()
+		if seen {
+			w.lastSeen[key] = prev
+		} else {
+			delete(w.lastSeen, key)
+		}
+		w.mu.Unlock()
+		return
+	}
+	w.logger.Info("reconciled",
+		"id", c.ID(),
+		"status", string(status),
+	)
+}
+
+// computeApplicationStatus maps status.health.status to a
+// component.Status. The second return is false only for `Suspended`
+// — callers skip the upsert in that case to preserve the previously
+// recorded status.
+//
+// Explicit `Unknown` and unrecognized future values map to
+// StatusUnknown (with ok=true) rather than preserve-previous. ArgoCD
+// reports Unknown when it has lost the health signal (repo-server
+// hiccup, failed refresh, missing health check), and preserving a
+// stale `operational` while we genuinely don't know the state would
+// be a status-page lie.
+//
+// Returns (StatusUnknown, true) when the field is missing entirely
+// (typical for an Application that ArgoCD has not yet observed) so
+// the initial state is recorded explicitly rather than left at the
+// SyncComponents default.
+func computeApplicationStatus(u *unstructured.Unstructured) (component.Status, bool) {
+	health, found, err := unstructured.NestedString(u.Object, "status", "health", "status")
+	if err != nil || !found || health == "" {
+		return component.StatusUnknown, true
+	}
+	switch health {
+	case "Healthy":
+		return component.StatusOperational, true
+	case "Progressing":
+		return component.StatusDegraded, true
+	case "Degraded", "Missing":
+		return component.StatusDown, true
+	case "Unknown":
+		return component.StatusUnknown, true
+	case "Suspended":
+		return "", false
+	default:
+		return component.StatusUnknown, true
+	}
+}

--- a/internal/watcher/application_test.go
+++ b/internal/watcher/application_test.go
@@ -1,0 +1,503 @@
+package watcher
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/northwatchlabs/northwatch/internal/component"
+	"github.com/northwatchlabs/northwatch/internal/config"
+	"github.com/northwatchlabs/northwatch/internal/store"
+)
+
+// newAppDynamicClient returns a fake dynamic client wired with the
+// ApplicationGVR → ApplicationList mapping that dynamicinformer needs.
+func newAppDynamicClient() *dynfake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+	listKinds := map[schema.GroupVersionResource]string{
+		ApplicationGVR: "ApplicationList",
+	}
+	return dynfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
+}
+
+func newApplication(ns, name, health string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(ApplicationGVR.GroupVersion().WithKind("Application"))
+	u.SetNamespace(ns)
+	u.SetName(name)
+	if health != "" {
+		_ = unstructured.SetNestedField(u.Object, health, "status", "health", "status")
+	}
+	return u
+}
+
+func setAppHealth(t *testing.T, u *unstructured.Unstructured, health string) {
+	t.Helper()
+	if err := unstructured.SetNestedField(u.Object, health, "status", "health", "status"); err != nil {
+		t.Fatalf("set health: %v", err)
+	}
+}
+
+func startApplicationWatcher(t *testing.T, cs dynamic.Interface, rs store.Store, specs []config.Spec) func() {
+	t.Helper()
+	w := NewApplicationWatcher(cs, rs, specs, quietLogger())
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- w.Start(ctx) }()
+
+	select {
+	case <-w.Synced():
+	case <-time.After(2 * time.Second):
+		cancel()
+		select {
+		case err := <-errCh:
+			t.Fatalf("watcher did not sync within 2s (Start returned %v)", err)
+		case <-time.After(2 * time.Second):
+			t.Fatal("watcher did not sync within 2s and did not exit after cancel")
+		}
+	}
+
+	return func() {
+		cancel()
+		select {
+		case err := <-errCh:
+			if err != nil {
+				t.Errorf("Start returned error: %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("watcher did not stop within 2s of cancel")
+		}
+	}
+}
+
+func TestApplicationWatcher_HealthTransitions(t *testing.T) {
+	cs := newAppDynamicClient()
+	rs := newRecordStore()
+	specs := []config.Spec{{
+		Kind: "Application", Namespace: "argocd", Name: "my-app", DisplayName: "My App",
+	}}
+	stop := startApplicationWatcher(t, cs, rs, specs)
+	defer stop()
+
+	ctx := context.Background()
+	res := cs.Resource(ApplicationGVR).Namespace("argocd")
+
+	if _, err := res.Create(ctx, newApplication("argocd", "my-app", "Healthy"), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	rs.waitForCalls(t, 1)
+	if got := rs.snapshot()[0].Status; got != component.StatusOperational {
+		t.Errorf("[0] status = %q, want %q", got, component.StatusOperational)
+	}
+
+	cur, err := res.Get(ctx, "my-app", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	setAppHealth(t, cur, "Progressing")
+	if _, err := res.Update(ctx, cur, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("update degraded: %v", err)
+	}
+	rs.waitForCalls(t, 2)
+	if got := rs.snapshot()[1].Status; got != component.StatusDegraded {
+		t.Errorf("[1] status = %q, want %q", got, component.StatusDegraded)
+	}
+
+	cur, _ = res.Get(ctx, "my-app", metav1.GetOptions{})
+	setAppHealth(t, cur, "Degraded")
+	if _, err := res.Update(ctx, cur, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("update down: %v", err)
+	}
+	rs.waitForCalls(t, 3)
+	if got := rs.snapshot()[2].Status; got != component.StatusDown {
+		t.Errorf("[2] status = %q, want %q", got, component.StatusDown)
+	}
+
+	cur, _ = res.Get(ctx, "my-app", metav1.GetOptions{})
+	setAppHealth(t, cur, "Healthy")
+	if _, err := res.Update(ctx, cur, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("update operational: %v", err)
+	}
+	rs.waitForCalls(t, 4)
+	if got := rs.snapshot()[3].Status; got != component.StatusOperational {
+		t.Errorf("[3] status = %q, want %q", got, component.StatusOperational)
+	}
+}
+
+func TestApplicationWatcher_MissingMapsToDown(t *testing.T) {
+	cs := newAppDynamicClient()
+	rs := newRecordStore()
+	specs := []config.Spec{{
+		Kind: "Application", Namespace: "argocd", Name: "my-app",
+	}}
+	stop := startApplicationWatcher(t, cs, rs, specs)
+	defer stop()
+
+	ctx := context.Background()
+	res := cs.Resource(ApplicationGVR).Namespace("argocd")
+	if _, err := res.Create(ctx, newApplication("argocd", "my-app", "Missing"), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	rs.waitForCalls(t, 1)
+	if got := rs.snapshot()[0].Status; got != component.StatusDown {
+		t.Errorf("status = %q, want %q", got, component.StatusDown)
+	}
+}
+
+func TestApplicationWatcher_SuspendedPreservesStatus(t *testing.T) {
+	cs := newAppDynamicClient()
+	rs := newRecordStore()
+	specs := []config.Spec{{
+		Kind: "Application", Namespace: "argocd", Name: "my-app",
+	}}
+	stop := startApplicationWatcher(t, cs, rs, specs)
+	defer stop()
+
+	ctx := context.Background()
+	res := cs.Resource(ApplicationGVR).Namespace("argocd")
+
+	if _, err := res.Create(ctx, newApplication("argocd", "my-app", "Healthy"), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	rs.waitForCalls(t, 1)
+
+	// Healthy → Suspended must not produce a second upsert.
+	cur, _ := res.Get(ctx, "my-app", metav1.GetOptions{})
+	setAppHealth(t, cur, "Suspended")
+	if _, err := res.Update(ctx, cur, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("update suspended: %v", err)
+	}
+	rs.assertCountStable(t, 1)
+
+	// Suspended → Degraded resumes normal mapping and writes "down".
+	cur, _ = res.Get(ctx, "my-app", metav1.GetOptions{})
+	setAppHealth(t, cur, "Degraded")
+	if _, err := res.Update(ctx, cur, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("update degraded: %v", err)
+	}
+	rs.waitForCalls(t, 2)
+	if got := rs.snapshot()[1].Status; got != component.StatusDown {
+		t.Errorf("status after resume = %q, want %q", got, component.StatusDown)
+	}
+}
+
+func TestApplicationWatcher_UnknownMapsToUnknown(t *testing.T) {
+	cs := newAppDynamicClient()
+	rs := newRecordStore()
+	specs := []config.Spec{{
+		Kind: "Application", Namespace: "argocd", Name: "my-app",
+	}}
+	stop := startApplicationWatcher(t, cs, rs, specs)
+	defer stop()
+
+	ctx := context.Background()
+	res := cs.Resource(ApplicationGVR).Namespace("argocd")
+
+	if _, err := res.Create(ctx, newApplication("argocd", "my-app", "Healthy"), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	rs.waitForCalls(t, 1)
+	if got := rs.snapshot()[0].Status; got != component.StatusOperational {
+		t.Fatalf("[0] status = %q, want %q", got, component.StatusOperational)
+	}
+
+	// Healthy → Unknown surfaces the loss-of-signal: status must flip
+	// to unknown, not stay at operational.
+	cur, _ := res.Get(ctx, "my-app", metav1.GetOptions{})
+	setAppHealth(t, cur, "Unknown")
+	if _, err := res.Update(ctx, cur, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("update unknown: %v", err)
+	}
+	rs.waitForCalls(t, 2)
+	if got := rs.snapshot()[1].Status; got != component.StatusUnknown {
+		t.Errorf("[1] status = %q, want %q", got, component.StatusUnknown)
+	}
+}
+
+func TestApplicationWatcher_UnwatchedIgnored(t *testing.T) {
+	cs := newAppDynamicClient()
+	rs := newRecordStore()
+	specs := []config.Spec{{
+		Kind: "Application", Namespace: "argocd", Name: "watched",
+	}}
+	stop := startApplicationWatcher(t, cs, rs, specs)
+	defer stop()
+
+	ctx := context.Background()
+	res := cs.Resource(ApplicationGVR)
+
+	if _, err := res.Namespace("argocd").Create(ctx, newApplication("argocd", "other", "Healthy"), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create other: %v", err)
+	}
+	if _, err := res.Namespace("apps").Create(ctx, newApplication("apps", "watched", "Healthy"), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create other-ns: %v", err)
+	}
+	if _, err := res.Namespace("argocd").Create(ctx, newApplication("argocd", "watched", "Healthy"), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create watched: %v", err)
+	}
+
+	rs.waitForCalls(t, 1)
+	rs.assertCountStable(t, 1)
+	got := rs.snapshot()[0]
+	if got.Name != "watched" || got.Namespace != "argocd" {
+		t.Errorf("upserted wrong component: %+v", got)
+	}
+}
+
+func TestApplicationWatcher_StatusUnchangedNoOp(t *testing.T) {
+	cs := newAppDynamicClient()
+	rs := newRecordStore()
+	specs := []config.Spec{{
+		Kind: "Application", Namespace: "argocd", Name: "my-app",
+	}}
+	stop := startApplicationWatcher(t, cs, rs, specs)
+	defer stop()
+
+	ctx := context.Background()
+	res := cs.Resource(ApplicationGVR).Namespace("argocd")
+	if _, err := res.Create(ctx, newApplication("argocd", "my-app", "Healthy"), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	rs.waitForCalls(t, 1)
+
+	// Bump an unrelated annotation; health stays Healthy, no upsert.
+	cur, _ := res.Get(ctx, "my-app", metav1.GetOptions{})
+	cur.SetAnnotations(map[string]string{"x": "1"})
+	if _, err := res.Update(ctx, cur, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("update same: %v", err)
+	}
+	rs.assertCountStable(t, 1)
+
+	// Real change → upsert.
+	cur, _ = res.Get(ctx, "my-app", metav1.GetOptions{})
+	setAppHealth(t, cur, "Degraded")
+	if _, err := res.Update(ctx, cur, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("update changed: %v", err)
+	}
+	rs.waitForCalls(t, 2)
+}
+
+func TestApplicationWatcher_DeleteLeavesStatus(t *testing.T) {
+	cs := newAppDynamicClient()
+	rs := newRecordStore()
+	specs := []config.Spec{{
+		Kind: "Application", Namespace: "argocd", Name: "my-app",
+	}}
+	stop := startApplicationWatcher(t, cs, rs, specs)
+	defer stop()
+
+	ctx := context.Background()
+	res := cs.Resource(ApplicationGVR).Namespace("argocd")
+	if _, err := res.Create(ctx, newApplication("argocd", "my-app", "Degraded"), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	rs.waitForCalls(t, 1)
+	if got := rs.snapshot()[0].Status; got != component.StatusDown {
+		t.Fatalf("initial status = %q, want %q", got, component.StatusDown)
+	}
+
+	if err := res.Delete(ctx, "my-app", metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	rs.assertCountStable(t, 1)
+	if got := rs.snapshot()[0].Status; got != component.StatusDown {
+		t.Errorf("recorded status after delete = %q, want %q", got, component.StatusDown)
+	}
+}
+
+func TestApplicationWatcher_CrossKindIsolation(t *testing.T) {
+	cs := newAppDynamicClient()
+	rs := newRecordStore()
+	// Spec with matching (ns, name) but Kind=HelmRelease must NOT
+	// match an Application event.
+	specs := []config.Spec{{
+		Kind: "HelmRelease", Namespace: "argocd", Name: "my-app",
+	}}
+	stop := startApplicationWatcher(t, cs, rs, specs)
+	defer stop()
+
+	ctx := context.Background()
+	res := cs.Resource(ApplicationGVR).Namespace("argocd")
+	if _, err := res.Create(ctx, newApplication("argocd", "my-app", "Healthy"), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	rs.assertCountStable(t, 0)
+}
+
+func TestApplicationWatcher_DisplayNamePropagation(t *testing.T) {
+	cs := newAppDynamicClient()
+	rs := newRecordStore()
+	specs := []config.Spec{{
+		Kind: "Application", Namespace: "argocd", Name: "my-app", DisplayName: "Search API",
+	}}
+	stop := startApplicationWatcher(t, cs, rs, specs)
+	defer stop()
+
+	ctx := context.Background()
+	res := cs.Resource(ApplicationGVR).Namespace("argocd")
+	if _, err := res.Create(ctx, newApplication("argocd", "my-app", "Healthy"), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	rs.waitForCalls(t, 1)
+	got := rs.snapshot()[0]
+	if got.DisplayName != "Search API" {
+		t.Errorf("DisplayName = %q, want %q", got.DisplayName, "Search API")
+	}
+	if got.Kind != "Application" {
+		t.Errorf("Kind = %q, want %q", got.Kind, "Application")
+	}
+}
+
+// stubResourceDiscovery is the minimal applicationResourceDiscovery
+// impl used by the probe tests. The block channel lets the cancel
+// test exercise the ctx.Done() race without depending on a real
+// network round-trip.
+type stubResourceDiscovery struct {
+	list  *metav1.APIResourceList
+	err   error
+	block <-chan struct{}
+}
+
+func (s *stubResourceDiscovery) ServerResourcesForGroupVersion(string) (*metav1.APIResourceList, error) {
+	if s.block != nil {
+		<-s.block
+	}
+	return s.list, s.err
+}
+
+func TestApplicationCRDPresentVia_ResourcePresent(t *testing.T) {
+	disc := &stubResourceDiscovery{list: &metav1.APIResourceList{
+		GroupVersion: ApplicationGVR.GroupVersion().String(),
+		APIResources: []metav1.APIResource{
+			{Name: "rollouts"},
+			{Name: ApplicationGVR.Resource},
+		},
+	}}
+	ok, err := applicationCRDPresentVia(context.Background(), disc)
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !ok {
+		t.Errorf("ok = false, want true (applications resource present)")
+	}
+}
+
+func TestApplicationCRDPresentVia_ResourceAbsent(t *testing.T) {
+	// Rollouts-only cluster: argoproj.io/v1alpha1 is served, but
+	// only the Rollouts CRDs are registered — no `applications`.
+	disc := &stubResourceDiscovery{list: &metav1.APIResourceList{
+		GroupVersion: ApplicationGVR.GroupVersion().String(),
+		APIResources: []metav1.APIResource{
+			{Name: "rollouts"},
+			{Name: "analysisruns"},
+		},
+	}}
+	ok, err := applicationCRDPresentVia(context.Background(), disc)
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if ok {
+		t.Errorf("ok = true, want false (applications resource missing)")
+	}
+}
+
+func TestApplicationCRDPresentVia_GroupVersionNotFound(t *testing.T) {
+	// Non-ArgoCD, non-Rollouts cluster: ServerResourcesForGroupVersion
+	// returns a NotFound. Treat as absent, not error.
+	disc := &stubResourceDiscovery{err: apierrors.NewNotFound(
+		schema.GroupResource{Group: ApplicationGVR.Group, Resource: ""},
+		ApplicationGVR.GroupVersion().String(),
+	)}
+	ok, err := applicationCRDPresentVia(context.Background(), disc)
+	if err != nil {
+		t.Fatalf("err = %v, want nil (NotFound is clean absent)", err)
+	}
+	if ok {
+		t.Errorf("ok = true, want false on NotFound")
+	}
+}
+
+func TestApplicationCRDPresentVia_DiscoveryError(t *testing.T) {
+	wantErr := errors.New("apiserver unreachable")
+	disc := &stubResourceDiscovery{err: wantErr}
+	ok, err := applicationCRDPresentVia(context.Background(), disc)
+	if err == nil || !errors.Is(err, wantErr) {
+		t.Errorf("err = %v, want wrap of %v", err, wantErr)
+	}
+	if ok {
+		t.Errorf("ok = true, want false on error")
+	}
+}
+
+func TestApplicationCRDPresentVia_CtxCancelled(t *testing.T) {
+	block := make(chan struct{})
+	defer close(block)
+	disc := &stubResourceDiscovery{block: block}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan struct{})
+	var (
+		ok  bool
+		err error
+	)
+	go func() {
+		ok, err = applicationCRDPresentVia(ctx, disc)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("probe did not return after ctx cancel within 2s")
+	}
+	if err == nil || !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want wrap of context.Canceled", err)
+	}
+	if ok {
+		t.Errorf("ok = true, want false on cancel")
+	}
+}
+
+func TestComputeApplicationStatus(t *testing.T) {
+	cases := []struct {
+		name   string
+		health string
+		want   component.Status
+		wantOK bool
+	}{
+		{name: "Healthy → operational", health: "Healthy", want: component.StatusOperational, wantOK: true},
+		{name: "Progressing → degraded", health: "Progressing", want: component.StatusDegraded, wantOK: true},
+		{name: "Degraded → down", health: "Degraded", want: component.StatusDown, wantOK: true},
+		{name: "Missing → down", health: "Missing", want: component.StatusDown, wantOK: true},
+		{name: "Unknown → unknown", health: "Unknown", want: component.StatusUnknown, wantOK: true},
+		{name: "Suspended → preserve previous", health: "Suspended", want: "", wantOK: false},
+		{name: "unrecognized value → unknown", health: "Foobar", want: component.StatusUnknown, wantOK: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			u := newApplication("argocd", "my-app", tc.health)
+			got, ok := computeApplicationStatus(u)
+			if got != tc.want || ok != tc.wantOK {
+				t.Errorf("got (%q, %v), want (%q, %v)", got, ok, tc.want, tc.wantOK)
+			}
+		})
+	}
+
+	t.Run("no health field → unknown, ok", func(t *testing.T) {
+		u := newApplication("argocd", "my-app", "")
+		got, ok := computeApplicationStatus(u)
+		if got != component.StatusUnknown || !ok {
+			t.Errorf("got (%q, %v), want (%q, true)", got, ok, component.StatusUnknown)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Adds an ArgoCD `Application` watcher alongside the existing Deployment and HelmRelease watchers so ArgoCD users get first-class status reconciliation.
- Maps `status.health.status` to `component.Status` (`Healthy` → operational, `Progressing` → degraded, `Degraded`/`Missing` → down, `Unknown` → unknown, unrecognized → unknown). Only `Suspended` preserves the previously recorded status — it's an intentional operator action, not a loss of signal. The mapper returns `(Status, ok)`, so dedup state is untouched on a no-op and the next real transition still lands.
- Probes the exact `applications` resource via `ServerResourcesForGroupVersion` instead of just checking the group/version is registered. `argoproj.io/v1alpha1` is shared with Argo Rollouts and Argo Events, so a group-level check would falsely succeed on a Rollouts-only cluster and the informer would then fail to sync.
- Clusters without ArgoCD CRDs log one skip line at boot and continue serving — `NotFound` on the group/version is treated as a clean "absent" result.

Closes #18

## Test plan

- [x] `go test ./...` passes
- [x] `go build ./...` succeeds
- [x] `gofmt` clean
- [x] Probe behaviour covered by unit tests: applications resource present, applications resource absent on a served group/version (Rollouts-only scenario), group/version NotFound (non-ArgoCD cluster), discovery error wrapped, ctx-cancel returns
- [x] Status mapping covered by table-driven tests including Suspended preserve-previous and Healthy → Unknown → unknown transition

End-to-end verification against a live ArgoCD-managed cluster is deferred to #25 (killer-demo integration test) — no ArgoCD-enabled cluster is available in this development environment.