### PR TITLE
Resolve HelmRelease API version at boot (v2 → v2beta2 → v2beta1)

### DIFF
--- a/cmd/northwatch/main.go
+++ b/cmd/northwatch/main.go
@@ -391,13 +391,13 @@ func buildHelmReleaseWatcher(
 	window time.Duration,
 	clk clock.WithDelayedExecution,
 ) *watcher.HelmReleaseWatcher {
-	present, err := watcher.HelmReleaseCRDPresent(ctx, kc.Config)
+	gvr, ok, err := watcher.ResolveHelmReleaseGVR(ctx, kc.Config)
 	if err != nil {
 		logger.Warn("helmrelease CRD probe failed; skipping watcher", "err", err)
 		return nil
 	}
-	if !present {
-		logger.Info("Flux CRDs not present, skipping helmrelease watcher")
+	if !ok {
+		logger.Info("Flux HelmRelease CRDs not present, skipping helmrelease watcher")
 		return nil
 	}
 	dyn, err := dynamic.NewForConfig(kc.Config)
@@ -405,7 +405,8 @@ func buildHelmReleaseWatcher(
 		logger.Warn("dynamic client init failed; skipping helmrelease watcher", "err", err)
 		return nil
 	}
-	return watcher.NewHelmReleaseWatcher(dyn, st, specs, logger, window, clk)
+	logger.Info("helmrelease watcher resolved API version", "version", gvr.Version)
+	return watcher.NewHelmReleaseWatcher(dyn, st, specs, logger, window, clk, gvr)
 }
 
 // buildApplicationWatcher probes for the ArgoCD Application CRD and

--- a/internal/watcher/helmrelease.go
+++ b/internal/watcher/helmrelease.go
@@ -26,16 +26,22 @@ import (
 	"github.com/northwatchlabs/northwatch/internal/store"
 )
 
-// HelmReleaseGVR is the dynamic GroupVersionResource for Flux's
-// helm.toolkit.fluxcd.io/v2 HelmRelease custom resource.
-var HelmReleaseGVR = schema.GroupVersionResource{
-	Group:    "helm.toolkit.fluxcd.io",
-	Version:  "v2",
-	Resource: "helmreleases",
-}
+const (
+	helmReleaseGroup    = "helm.toolkit.fluxcd.io"
+	helmReleaseResource = "helmreleases"
+)
 
-// HelmReleaseCRDPresent returns true if helm.toolkit.fluxcd.io/v2 is
-// registered on the cluster's API server. Use to gate watcher
+// helmReleaseCandidateVersions lists HelmRelease API versions in our
+// preferred order. v2 went stable in Flux 2.3 (May 2024); v2beta2 was
+// the default through mid-2023; v2beta1 is older still. The Ready
+// condition shape we map is identical across all three, so picking
+// the newest version the cluster serves is purely a forward-looking
+// preference.
+var helmReleaseCandidateVersions = []string{"v2", "v2beta2", "v2beta1"}
+
+// ResolveHelmReleaseGVR probes the cluster's API server and returns
+// the most-preferred HelmRelease GVR served, or ok=false if none of
+// the candidate versions are registered. Use to gate watcher
 // construction so clusters without Flux installed boot cleanly
 // instead of crashing on a missing CRD.
 //
@@ -45,24 +51,24 @@ var HelmReleaseGVR = schema.GroupVersionResource{
 // list/watch streams must outlive the timeout. ctx is honored even
 // though client-go v0.35's discovery API has no context-accepting
 // variant; the in-flight request is raced against ctx.Done() via a
-// goroutine in helmReleaseCRDPresentVia.
-func HelmReleaseCRDPresent(ctx context.Context, cfg *rest.Config) (bool, error) {
+// goroutine in resolveHelmReleaseGVRVia.
+func ResolveHelmReleaseGVR(ctx context.Context, cfg *rest.Config) (schema.GroupVersionResource, bool, error) {
 	probeCfg := rest.CopyConfig(cfg)
 	probeCfg.Timeout = pingTimeout
 
 	disc, err := discovery.NewDiscoveryClientForConfig(probeCfg)
 	if err != nil {
-		return false, fmt.Errorf("build discovery client: %w", err)
+		return schema.GroupVersionResource{}, false, fmt.Errorf("build discovery client: %w", err)
 	}
-	return helmReleaseCRDPresentVia(ctx, disc)
+	return resolveHelmReleaseGVRVia(ctx, disc)
 }
 
-// helmReleaseCRDPresentVia is the testable seam: it accepts a
+// resolveHelmReleaseGVRVia is the testable seam: it accepts a
 // pre-built ServerGroupsInterface so tests can drive it with a fake
 // without spinning up an HTTP server. The cancellation race against
 // ctx.Done() lives here so the goroutine semantics are exercised by
 // unit tests.
-func helmReleaseCRDPresentVia(ctx context.Context, disc discovery.ServerGroupsInterface) (bool, error) {
+func resolveHelmReleaseGVRVia(ctx context.Context, disc discovery.ServerGroupsInterface) (schema.GroupVersionResource, bool, error) {
 	type result struct {
 		groups *metav1.APIGroupList
 		err    error
@@ -76,25 +82,34 @@ func helmReleaseCRDPresentVia(ctx context.Context, disc discovery.ServerGroupsIn
 	var groups *metav1.APIGroupList
 	select {
 	case <-ctx.Done():
-		return false, fmt.Errorf("helmrelease CRD probe cancelled: %w", ctx.Err())
+		return schema.GroupVersionResource{}, false, fmt.Errorf("helmrelease CRD probe cancelled: %w", ctx.Err())
 	case r := <-resultCh:
 		if r.err != nil {
-			return false, fmt.Errorf("list server groups: %w", r.err)
+			return schema.GroupVersionResource{}, false, fmt.Errorf("list server groups: %w", r.err)
 		}
 		groups = r.groups
 	}
 
+	served := make(map[string]struct{})
 	for _, g := range groups.Groups {
-		if g.Name != HelmReleaseGVR.Group {
+		if g.Name != helmReleaseGroup {
 			continue
 		}
 		for _, v := range g.Versions {
-			if v.Version == HelmReleaseGVR.Version {
-				return true, nil
-			}
+			served[v.Version] = struct{}{}
+		}
+		break
+	}
+	for _, v := range helmReleaseCandidateVersions {
+		if _, ok := served[v]; ok {
+			return schema.GroupVersionResource{
+				Group:    helmReleaseGroup,
+				Version:  v,
+				Resource: helmReleaseResource,
+			}, true, nil
 		}
 	}
-	return false, nil
+	return schema.GroupVersionResource{}, false, nil
 }
 
 // HelmReleaseWatcher watches HelmRelease events for the configured
@@ -113,6 +128,7 @@ type HelmReleaseWatcher struct {
 	logger  *slog.Logger
 	window  time.Duration
 	clk     clock.WithDelayedExecution
+	gvr     schema.GroupVersionResource
 
 	// populated in Start once the informer factory exists
 	lister    cache.GenericLister
@@ -136,6 +152,7 @@ func NewHelmReleaseWatcher(
 	logger *slog.Logger,
 	window time.Duration,
 	clk clock.WithDelayedExecution,
+	gvr schema.GroupVersionResource,
 ) *HelmReleaseWatcher {
 	if logger == nil {
 		logger = slog.Default()
@@ -158,6 +175,7 @@ func NewHelmReleaseWatcher(
 		logger:   logger.With("watcher", "helmrelease"),
 		window:   window,
 		clk:      clk,
+		gvr:      gvr,
 		syncedCh: make(chan struct{}),
 	}
 }
@@ -173,8 +191,8 @@ func (w *HelmReleaseWatcher) Synced() <-chan struct{} {
 func (w *HelmReleaseWatcher) Start(ctx context.Context) error {
 	w.ctx = ctx
 	factory := dynamicinformer.NewDynamicSharedInformerFactory(w.client, 0)
-	informer := factory.ForResource(HelmReleaseGVR).Informer()
-	w.lister = factory.ForResource(HelmReleaseGVR).Lister()
+	informer := factory.ForResource(w.gvr).Informer()
+	w.lister = factory.ForResource(w.gvr).Lister()
 	w.debouncer = status.NewDebouncer(w.window, w.clk, w.retry)
 	defer w.debouncer.Stop()
 

--- a/internal/watcher/helmrelease_test.go
+++ b/internal/watcher/helmrelease_test.go
@@ -18,6 +18,15 @@ import (
 	"github.com/northwatchlabs/northwatch/internal/store"
 )
 
+// helmReleaseV2GVR is the v2 GVR used across the watcher tests. The
+// probe-resolution tests in this file exercise fallback to v2beta2 /
+// v2beta1, but the dynamic-informer tests only need a single GVR.
+var helmReleaseV2GVR = schema.GroupVersionResource{
+	Group:    helmReleaseGroup,
+	Version:  "v2",
+	Resource: helmReleaseResource,
+}
+
 // newDynamicClient returns a fake dynamic client wired with the GVR
 // → list-kind mapping that dynamicinformer needs to construct
 // informers. Without the list-kind mapping the informer panics on
@@ -26,14 +35,14 @@ import (
 func newDynamicClient() *dynfake.FakeDynamicClient {
 	scheme := runtime.NewScheme()
 	listKinds := map[schema.GroupVersionResource]string{
-		HelmReleaseGVR: "HelmReleaseList",
+		helmReleaseV2GVR: "HelmReleaseList",
 	}
 	return dynfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
 }
 
 func newHelmRelease(ns, name, readyStatus, readyReason string) *unstructured.Unstructured {
 	u := &unstructured.Unstructured{}
-	u.SetGroupVersionKind(HelmReleaseGVR.GroupVersion().WithKind("HelmRelease"))
+	u.SetGroupVersionKind(helmReleaseV2GVR.GroupVersion().WithKind("HelmRelease"))
 	u.SetNamespace(ns)
 	u.SetName(name)
 	if readyStatus != "" {
@@ -51,7 +60,7 @@ func newHelmRelease(ns, name, readyStatus, readyReason string) *unstructured.Uns
 
 func startHelmReleaseWatcher(t *testing.T, cs dynamic.Interface, rs store.Store, specs []config.Spec) func() {
 	t.Helper()
-	w := NewHelmReleaseWatcher(cs, rs, specs, quietLogger(), 0, nil)
+	w := NewHelmReleaseWatcher(cs, rs, specs, quietLogger(), 0, nil, helmReleaseV2GVR)
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
 	go func() { errCh <- w.Start(ctx) }()
@@ -91,7 +100,7 @@ func TestHelmReleaseWatcher_ReadyTransitions(t *testing.T) {
 	defer stop()
 
 	ctx := context.Background()
-	res := cs.Resource(HelmReleaseGVR).Namespace("flux-system")
+	res := cs.Resource(helmReleaseV2GVR).Namespace("flux-system")
 
 	// operational: Ready=True
 	if _, err := res.Create(ctx, newHelmRelease("flux-system", "my-app", "True", "ReconciliationSucceeded"), metav1.CreateOptions{}); err != nil {
@@ -155,7 +164,7 @@ func TestHelmReleaseWatcher_UnwatchedIgnored(t *testing.T) {
 	defer stop()
 
 	ctx := context.Background()
-	res := cs.Resource(HelmReleaseGVR)
+	res := cs.Resource(helmReleaseV2GVR)
 
 	if _, err := res.Namespace("flux-system").Create(ctx, newHelmRelease("flux-system", "other", "True", "ok"), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("create other: %v", err)
@@ -185,7 +194,7 @@ func TestHelmReleaseWatcher_StatusUnchangedNoOp(t *testing.T) {
 	defer stop()
 
 	ctx := context.Background()
-	res := cs.Resource(HelmReleaseGVR).Namespace("flux-system")
+	res := cs.Resource(helmReleaseV2GVR).Namespace("flux-system")
 	if _, err := res.Create(ctx, newHelmRelease("flux-system", "my-app", "True", "ok"), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -223,7 +232,7 @@ func TestHelmReleaseWatcher_DeleteLeavesStatus(t *testing.T) {
 	defer stop()
 
 	ctx := context.Background()
-	res := cs.Resource(HelmReleaseGVR).Namespace("flux-system")
+	res := cs.Resource(helmReleaseV2GVR).Namespace("flux-system")
 	if _, err := res.Create(ctx, newHelmRelease("flux-system", "my-app", "False", "InstallFailed"), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -253,7 +262,7 @@ func TestHelmReleaseWatcher_CrossKindIsolation(t *testing.T) {
 	defer stop()
 
 	ctx := context.Background()
-	res := cs.Resource(HelmReleaseGVR).Namespace("flux-system")
+	res := cs.Resource(helmReleaseV2GVR).Namespace("flux-system")
 	if _, err := res.Create(ctx, newHelmRelease("flux-system", "my-app", "True", "ok"), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -270,7 +279,7 @@ func TestHelmReleaseWatcher_DisplayNamePropagation(t *testing.T) {
 	defer stop()
 
 	ctx := context.Background()
-	res := cs.Resource(HelmReleaseGVR).Namespace("flux-system")
+	res := cs.Resource(helmReleaseV2GVR).Namespace("flux-system")
 	if _, err := res.Create(ctx, newHelmRelease("flux-system", "my-app", "True", "ok"), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -286,7 +295,7 @@ func TestHelmReleaseWatcher_DisplayNamePropagation(t *testing.T) {
 
 // stubDiscovery is a minimal ServerGroupsInterface impl used by the
 // CRD-probe tests. Returning an error or blocking lets us exercise
-// the error and ctx.Done() arms of helmReleaseCRDPresentVia without
+// the error and ctx.Done() arms of resolveHelmReleaseGVRVia without
 // reaching for client-go's discovery fakes (which assume a real
 // REST round-trip).
 type stubDiscovery struct {
@@ -302,27 +311,68 @@ func (s *stubDiscovery) ServerGroups() (*metav1.APIGroupList, error) {
 	return s.groups, s.err
 }
 
-func TestHelmReleaseCRDPresentVia_Present(t *testing.T) {
-	disc := &stubDiscovery{groups: &metav1.APIGroupList{Groups: []metav1.APIGroup{
+// helmReleaseGroups builds an APIGroupList where the Flux HelmRelease
+// group serves exactly the given versions. The order is preserved so
+// tests can assert the resolver's preference order rather than the
+// server's discovery order.
+func helmReleaseGroups(versions ...string) *metav1.APIGroupList {
+	gvs := make([]metav1.GroupVersionForDiscovery, 0, len(versions))
+	for _, v := range versions {
+		gvs = append(gvs, metav1.GroupVersionForDiscovery{Version: v})
+	}
+	return &metav1.APIGroupList{Groups: []metav1.APIGroup{
 		{Name: "apps", Versions: []metav1.GroupVersionForDiscovery{{Version: "v1"}}},
-		{Name: HelmReleaseGVR.Group, Versions: []metav1.GroupVersionForDiscovery{
-			{Version: "v2beta1"}, {Version: HelmReleaseGVR.Version},
-		}},
-	}}}
-	ok, err := helmReleaseCRDPresentVia(context.Background(), disc)
+		{Name: helmReleaseGroup, Versions: gvs},
+	}}
+}
+
+func TestResolveHelmReleaseGVRVia_PrefersV2(t *testing.T) {
+	disc := &stubDiscovery{groups: helmReleaseGroups("v2beta1", "v2beta2", "v2")}
+	gvr, ok, err := resolveHelmReleaseGVRVia(context.Background(), disc)
 	if err != nil {
 		t.Fatalf("err = %v, want nil", err)
 	}
 	if !ok {
-		t.Errorf("ok = false, want true (Flux v2 group present)")
+		t.Fatalf("ok = false, want true (all versions present)")
+	}
+	if gvr.Version != "v2" {
+		t.Errorf("gvr.Version = %q, want %q", gvr.Version, "v2")
 	}
 }
 
-func TestHelmReleaseCRDPresentVia_AbsentGroup(t *testing.T) {
+func TestResolveHelmReleaseGVRVia_FallsBackToV2Beta2(t *testing.T) {
+	disc := &stubDiscovery{groups: helmReleaseGroups("v2beta1", "v2beta2")}
+	gvr, ok, err := resolveHelmReleaseGVRVia(context.Background(), disc)
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !ok {
+		t.Fatalf("ok = false, want true (v2beta2 served)")
+	}
+	if gvr.Version != "v2beta2" {
+		t.Errorf("gvr.Version = %q, want %q", gvr.Version, "v2beta2")
+	}
+}
+
+func TestResolveHelmReleaseGVRVia_FallsBackToV2Beta1(t *testing.T) {
+	disc := &stubDiscovery{groups: helmReleaseGroups("v2beta1")}
+	gvr, ok, err := resolveHelmReleaseGVRVia(context.Background(), disc)
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !ok {
+		t.Fatalf("ok = false, want true (v2beta1 served)")
+	}
+	if gvr.Version != "v2beta1" {
+		t.Errorf("gvr.Version = %q, want %q", gvr.Version, "v2beta1")
+	}
+}
+
+func TestResolveHelmReleaseGVRVia_AbsentGroup(t *testing.T) {
 	disc := &stubDiscovery{groups: &metav1.APIGroupList{Groups: []metav1.APIGroup{
 		{Name: "apps", Versions: []metav1.GroupVersionForDiscovery{{Version: "v1"}}},
 	}}}
-	ok, err := helmReleaseCRDPresentVia(context.Background(), disc)
+	_, ok, err := resolveHelmReleaseGVRVia(context.Background(), disc)
 	if err != nil {
 		t.Fatalf("err = %v, want nil", err)
 	}
@@ -331,25 +381,24 @@ func TestHelmReleaseCRDPresentVia_AbsentGroup(t *testing.T) {
 	}
 }
 
-func TestHelmReleaseCRDPresentVia_GroupPresentWrongVersion(t *testing.T) {
-	disc := &stubDiscovery{groups: &metav1.APIGroupList{Groups: []metav1.APIGroup{
-		{Name: HelmReleaseGVR.Group, Versions: []metav1.GroupVersionForDiscovery{
-			{Version: "v2beta1"}, {Version: "v2beta2"},
-		}},
-	}}}
-	ok, err := helmReleaseCRDPresentVia(context.Background(), disc)
+func TestResolveHelmReleaseGVRVia_NoKnownVersionServed(t *testing.T) {
+	// Group present, but only some unrelated future version. The
+	// resolver must return not-found rather than picking the unknown
+	// version blindly.
+	disc := &stubDiscovery{groups: helmReleaseGroups("v3alpha1")}
+	_, ok, err := resolveHelmReleaseGVRVia(context.Background(), disc)
 	if err != nil {
 		t.Fatalf("err = %v, want nil", err)
 	}
 	if ok {
-		t.Errorf("ok = true, want false (only legacy versions present, no v2)")
+		t.Errorf("ok = true, want false (no candidate version served)")
 	}
 }
 
-func TestHelmReleaseCRDPresentVia_DiscoveryError(t *testing.T) {
+func TestResolveHelmReleaseGVRVia_DiscoveryError(t *testing.T) {
 	wantErr := errors.New("apiserver unreachable")
 	disc := &stubDiscovery{err: wantErr}
-	ok, err := helmReleaseCRDPresentVia(context.Background(), disc)
+	_, ok, err := resolveHelmReleaseGVRVia(context.Background(), disc)
 	if err == nil || !errors.Is(err, wantErr) {
 		t.Errorf("err = %v, want wrap of %v", err, wantErr)
 	}
@@ -358,7 +407,7 @@ func TestHelmReleaseCRDPresentVia_DiscoveryError(t *testing.T) {
 	}
 }
 
-func TestHelmReleaseCRDPresentVia_CtxCancelled(t *testing.T) {
+func TestResolveHelmReleaseGVRVia_CtxCancelled(t *testing.T) {
 	// Block ServerGroups forever; cancel the context immediately.
 	// The probe must return without waiting for the in-flight call.
 	block := make(chan struct{})
@@ -374,7 +423,7 @@ func TestHelmReleaseCRDPresentVia_CtxCancelled(t *testing.T) {
 		err error
 	)
 	go func() {
-		ok, err = helmReleaseCRDPresentVia(ctx, disc)
+		_, ok, err = resolveHelmReleaseGVRVia(ctx, disc)
 		close(done)
 	}()
 	select {


### PR DESCRIPTION
## Summary
- Replace v2-only HelmRelease CRD probe with `ResolveHelmReleaseGVR`, which selects the most-preferred served version in order `v2 → v2beta2 → v2beta1`.
- `HelmReleaseWatcher` carries the resolved GVR; `main.go` logs the chosen version and uses a HelmRelease-specific skip message when no candidate version is served.
- Ready-condition mapping is unchanged — the shape is identical across all three versions, so `status.MapHelmRelease` needs no edits.

Closes #52

## Test plan
- [x] `go test ./...` passes (full suite + new resolver cases for v2 preference, fallback to v2beta2, fallback to v2beta1, no-known-version-served, group-absent, discovery error, ctx-cancellation).
- [x] `go vet ./...` clean.
- [x] `golangci-lint run ./...` reports 0 issues.
- [x] Manual check in a kind cluster with only `v2beta2` served: watcher logs `version=v2beta2` and reconciles a Ready=True HelmRelease to `operational`.
- [x] Cluster with no HelmRelease CRD: log `"Flux HelmRelease CRDs not present, skipping helmrelease watcher"`, no crash.