### PR TITLE
Watch Flux Kustomizations and reconcile component status

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,13 @@ kubectl --context kind-nw-demo -n default scale deploy/api-gateway --replicas=3
 ```
 
 The component config (`examples/basic/northwatch.yaml`) also lists
-`HelmRelease/flux-system/cert-manager` and an ArgoCD `Application`,
-which will show as `unknown` until those controllers are installed.
-The CRD probe logs `"Flux CRDs not present, skipping helmrelease
-watcher"` and continues — that's expected.
+`HelmRelease/flux-system/cert-manager`, an ArgoCD `Application`, and
+a Flux `Kustomization`, which will show as `unknown` until those
+controllers are installed. The CRD probes log
+`"Flux HelmRelease CRDs not present, skipping helmrelease watcher"`
+(and the parallel `"ArgoCD CRDs not present, skipping application
+watcher"` / `"Flux Kustomize CRDs not present, skipping kustomization
+watcher"`) and continue — that's expected.
 
 ### 3. (Optional) Watch a HelmRelease
 
@@ -95,6 +98,48 @@ non-existent version:
 ```sh
 kubectl --context kind-nw-demo -n default patch hr podinfo \
     --type merge -p '{"spec":{"chart":{"spec":{"version":"999.0.0"}}}}'
+```
+
+### 4. (Optional) Watch a Flux Kustomization
+
+To exercise the Kustomization watcher, install Flux's source and
+kustomize controllers and apply a real Kustomization. The recipe
+below uses `stefanprodan/podinfo` because it ships a ready-to-use
+`/kustomize/` path — no scratch repo needed:
+
+```sh
+flux --context kind-nw-demo install \
+    --components=source-controller,kustomize-controller
+
+bash -c "kubectl --context kind-nw-demo apply -f - <<'EOF'
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata: { name: podinfo, namespace: default }
+spec:
+  interval: 5m
+  url: https://github.com/stefanprodan/podinfo
+  ref: { branch: master }
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: { name: podinfo, namespace: default }
+spec:
+  interval: 5m
+  path: ./kustomize
+  prune: true
+  sourceRef: { kind: GitRepository, name: podinfo }
+  targetNamespace: default
+EOF
+"
+```
+
+Point a config entry at `Kustomization/default/podinfo`, restart
+`northwatch`, and the Kustomization renders as `operational` once
+Flux reconciles it. To watch it flip to `down`, break the path:
+
+```sh
+kubectl --context kind-nw-demo -n default patch ks podinfo \
+    --type merge -p '{"spec":{"path":"./does-not-exist"}}'
 ```
 
 ### Cleanup

--- a/cmd/northwatch/main.go
+++ b/cmd/northwatch/main.go
@@ -181,7 +181,7 @@ func serveCmd(args []string) int {
 	// calling srv.Shutdown. Sized for all watchers plus the HTTP
 	// server so a real failure can't block its sender during the
 	// shutdown window.
-	errCh := make(chan error, 4)
+	errCh := make(chan error, 5)
 	go func() {
 		logger.Info("listening", "addr", srv.Addr, "db", *dbPath)
 		errCh <- srv.ListenAndServe()
@@ -203,6 +203,13 @@ func serveCmd(args []string) int {
 		if appWatcher := buildApplicationWatcher(ctx, kc, st, cfg.Components, logger, window, clock.RealClock{}); appWatcher != nil {
 			go func() {
 				if err := appWatcher.Start(ctx); err != nil {
+					errCh <- err
+				}
+			}()
+		}
+		if ksWatcher := buildKustomizationWatcher(ctx, kc, st, cfg.Components, logger, window, clock.RealClock{}); ksWatcher != nil {
+			go func() {
+				if err := ksWatcher.Start(ctx); err != nil {
 					errCh <- err
 				}
 			}()
@@ -439,6 +446,39 @@ func buildApplicationWatcher(
 		return nil
 	}
 	return watcher.NewApplicationWatcher(dyn, st, specs, logger, window, clk)
+}
+
+// buildKustomizationWatcher probes for the Flux Kustomization CRD
+// and constructs the watcher only when it's present. Returns nil
+// when the CRD is missing — the cluster just doesn't run Flux's
+// kustomize-controller, which is expected on non-GitOps clusters or
+// HelmRelease-only Flux setups. A probe error is logged but
+// otherwise treated as "absent" so a transient discovery failure
+// doesn't take serve down.
+func buildKustomizationWatcher(
+	ctx context.Context,
+	kc *watcher.Client,
+	st store.Store,
+	specs []config.Spec,
+	logger *slog.Logger,
+	window time.Duration,
+	clk clock.WithDelayedExecution,
+) *watcher.KustomizationWatcher {
+	present, err := watcher.KustomizationCRDPresent(ctx, kc.Config)
+	if err != nil {
+		logger.Warn("kustomization CRD probe failed; skipping watcher", "err", err)
+		return nil
+	}
+	if !present {
+		logger.Info("Flux Kustomize CRDs not present, skipping kustomization watcher")
+		return nil
+	}
+	dyn, err := dynamic.NewForConfig(kc.Config)
+	if err != nil {
+		logger.Warn("dynamic client init failed; skipping kustomization watcher", "err", err)
+		return nil
+	}
+	return watcher.NewKustomizationWatcher(dyn, st, specs, logger, window, clk, watcher.KustomizationGVR)
 }
 
 func normalizeAddr(addr string) string {

--- a/examples/basic/northwatch.yaml
+++ b/examples/basic/northwatch.yaml
@@ -11,3 +11,7 @@ components:
     namespace: argocd
     name: payments
     displayName: "Payments Service"
+  - kind: Kustomization
+    namespace: flux-system
+    name: infra
+    displayName: "Infra (Flux Kustomization)"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,9 +70,10 @@ func (e *ValidationError) Error() string {
 }
 
 var allowedKinds = map[string]struct{}{
-	"Deployment":  {},
-	"HelmRelease": {},
-	"Application": {},
+	"Deployment":    {},
+	"HelmRelease":   {},
+	"Application":   {},
+	"Kustomization": {},
 }
 
 // Validate runs every rule against f and returns *ValidationError
@@ -92,7 +93,7 @@ func (f *File) Validate() error {
 			errs = append(errs, fmt.Errorf("components[%d]: kind is required", i))
 		} else if _, ok := allowedKinds[c.Kind]; !ok {
 			errs = append(errs, fmt.Errorf(
-				"components[%d]: kind %q is not one of Deployment, HelmRelease, Application",
+				"components[%d]: kind %q is not one of Deployment, HelmRelease, Application, Kustomization",
 				i, c.Kind,
 			))
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -24,6 +24,10 @@ components:
     namespace: argocd
     name: payments
     displayName: "Payments Service"
+  - kind: Kustomization
+    namespace: flux-system
+    name: infra
+    displayName: "Infra Kustomization"
 `
 
 // writeTempConfig writes body to a fresh tempfile and returns its
@@ -44,8 +48,8 @@ func TestLoad_Valid(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if len(f.Components) != 3 {
-		t.Fatalf("len(Components) = %d, want 3", len(f.Components))
+	if len(f.Components) != 4 {
+		t.Fatalf("len(Components) = %d, want 4", len(f.Components))
 	}
 	if got, want := f.Components[0].Kind, "Deployment"; got != want {
 		t.Errorf("[0].Kind = %q, want %q", got, want)
@@ -55,6 +59,9 @@ func TestLoad_Valid(t *testing.T) {
 	}
 	if got, want := f.Components[2].Name, "payments"; got != want {
 		t.Errorf("[2].Name = %q, want %q", got, want)
+	}
+	if got, want := f.Components[3].Kind, "Kustomization"; got != want {
+		t.Errorf("[3].Kind = %q, want %q", got, want)
 	}
 }
 

--- a/internal/status/mapper.go
+++ b/internal/status/mapper.go
@@ -16,6 +16,33 @@ import (
 //   - Ready=False, other reason        → down
 //   - Ready missing/Unknown            → unknown
 func MapHelmRelease(u *unstructured.Unstructured) component.Status {
+	return mapReadyCondition(u)
+}
+
+// MapKustomization returns the component status for a Flux
+// Kustomization (kustomize.toolkit.fluxcd.io/v1) based on
+// status.conditions[type=Ready].
+//
+//   - Ready=True                       → operational
+//   - Ready=False, reason=Progressing  → degraded
+//   - Ready=False, other reason        → down
+//   - Ready missing/Unknown            → unknown
+//
+// kustomize-controller also surfaces separate Reconciling and Stalled
+// conditions (kstatus). Inspecting those is tracked separately (#57)
+// and must land symmetrically in MapHelmRelease and MapKustomization.
+func MapKustomization(u *unstructured.Unstructured) component.Status {
+	return mapReadyCondition(u)
+}
+
+// mapReadyCondition is the shared Ready-condition mapper used by
+// MapHelmRelease and MapKustomization. Both Flux controllers report
+// reconcile state through status.conditions[type=Ready] with the
+// same shape: status ∈ {True,False,Unknown}, reason ∈ {Progressing,
+// <controller-specific failure reasons>...}. Keep the two exported
+// functions as thin delegates so a future kstatus-aware mapper (see
+// #57) can swap the implementation in one place.
+func mapReadyCondition(u *unstructured.Unstructured) component.Status {
 	conds, found, err := unstructured.NestedSlice(u.Object, "status", "conditions")
 	if err != nil || !found {
 		return component.StatusUnknown

--- a/internal/status/mapper_test.go
+++ b/internal/status/mapper_test.go
@@ -61,6 +61,91 @@ func TestMapHelmRelease(t *testing.T) {
 	}
 }
 
+func TestMapKustomization(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ks   *unstructured.Unstructured
+		want component.Status
+	}{
+		{
+			name: "Ready=True maps to operational",
+			ks:   kustomizationWithReady("True", "ReconciliationSucceeded"),
+			want: component.StatusOperational,
+		},
+		{
+			name: "Ready=False, reason=Progressing maps to degraded",
+			ks:   kustomizationWithReady("False", "Progressing"),
+			want: component.StatusDegraded,
+		},
+		{
+			name: "Ready=False, reason=BuildFailed maps to down",
+			ks:   kustomizationWithReady("False", "BuildFailed"),
+			want: component.StatusDown,
+		},
+		{
+			name: "Ready=False, reason=HealthCheckFailed maps to down",
+			ks:   kustomizationWithReady("False", "HealthCheckFailed"),
+			want: component.StatusDown,
+		},
+		{
+			name: "Ready missing maps to unknown",
+			ks:   newKustomization(map[string]interface{}{"status": map[string]interface{}{}}),
+			want: component.StatusUnknown,
+		},
+		{
+			name: "Ready=Unknown maps to unknown",
+			ks:   kustomizationWithReady("Unknown", ""),
+			want: component.StatusUnknown,
+		},
+		{
+			name: "no status.conditions at all maps to unknown",
+			ks:   newKustomization(nil),
+			want: component.StatusUnknown,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MapKustomization(tc.ks)
+			if got != tc.want {
+				t.Fatalf("MapKustomization = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func kustomizationWithReady(readyStatus, reason string) *unstructured.Unstructured {
+	cond := map[string]interface{}{
+		"type":   "Ready",
+		"status": readyStatus,
+	}
+	if reason != "" {
+		cond["reason"] = reason
+	}
+	return newKustomization(map[string]interface{}{
+		"status": map[string]interface{}{
+			"conditions": []interface{}{cond},
+		},
+	})
+}
+
+func newKustomization(obj map[string]interface{}) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "kustomize.toolkit.fluxcd.io",
+		Version: "v1",
+		Kind:    "Kustomization",
+	})
+	u.SetNamespace("default")
+	u.SetName("test")
+	for k, v := range obj {
+		u.Object[k] = v
+	}
+	return u
+}
+
 func helmReleaseWithReady(readyStatus, reason string) *unstructured.Unstructured {
 	cond := map[string]interface{}{
 		"type":   "Ready",

--- a/internal/watcher/kustomization.go
+++ b/internal/watcher/kustomization.go
@@ -1,0 +1,316 @@
+package watcher
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/clock"
+
+	"github.com/northwatchlabs/northwatch/internal/component"
+	"github.com/northwatchlabs/northwatch/internal/config"
+	"github.com/northwatchlabs/northwatch/internal/status"
+	"github.com/northwatchlabs/northwatch/internal/store"
+)
+
+// KustomizationGVR is the dynamic GroupVersionResource for Flux's
+// kustomize.toolkit.fluxcd.io/v1 Kustomization custom resource. Flux
+// 2.0 (July 2023) stabilized v1; pre-v1 versions are EOL and not
+// supported here. If clusters running ancient Flux need to be
+// supported later, add a multi-version resolver paralleling
+// ResolveHelmReleaseGVR.
+var KustomizationGVR = schema.GroupVersionResource{
+	Group:    "kustomize.toolkit.fluxcd.io",
+	Version:  "v1",
+	Resource: "kustomizations",
+}
+
+// KustomizationCRDPresent returns true when the Flux Kustomization
+// CRD (kustomize.toolkit.fluxcd.io/v1.kustomizations) is served by
+// the cluster. Use to gate watcher construction so clusters without
+// Flux's kustomize-controller boot cleanly instead of failing the
+// informer sync on a missing CRD.
+//
+// The probe checks the resource list for KustomizationGVR.GroupVersion
+// and verifies kustomizations appears in the resources — not just
+// that the group/version is registered — so a cluster with the group
+// registered for some unrelated resource doesn't false-positive.
+//
+// A copied rest.Config caps discovery at pingTimeout so a stalled
+// endpoint can't hang serve startup or SIGTERM handling, and the
+// in-flight request is raced against ctx.Done() via a goroutine in
+// kustomizationCRDPresentVia.
+func KustomizationCRDPresent(ctx context.Context, cfg *rest.Config) (bool, error) {
+	probeCfg := rest.CopyConfig(cfg)
+	probeCfg.Timeout = pingTimeout
+
+	disc, err := discovery.NewDiscoveryClientForConfig(probeCfg)
+	if err != nil {
+		return false, fmt.Errorf("build discovery client: %w", err)
+	}
+	return kustomizationCRDPresentVia(ctx, disc)
+}
+
+// kustomizationResourceDiscovery is the small surface
+// kustomizationCRDPresentVia needs — narrower than
+// discovery.DiscoveryInterface so tests can drive it with a tiny stub.
+type kustomizationResourceDiscovery interface {
+	ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error)
+}
+
+// kustomizationCRDPresentVia is the testable seam. A NotFound from
+// ServerResourcesForGroupVersion means the group/version is not
+// served at all (the common non-Flux cluster) and is treated as a
+// clean "absent" result rather than a probe failure.
+func kustomizationCRDPresentVia(ctx context.Context, disc kustomizationResourceDiscovery) (bool, error) {
+	type result struct {
+		list *metav1.APIResourceList
+		err  error
+	}
+	resultCh := make(chan result, 1)
+	gv := KustomizationGVR.GroupVersion().String()
+	go func() {
+		list, err := disc.ServerResourcesForGroupVersion(gv)
+		resultCh <- result{list: list, err: err}
+	}()
+
+	var list *metav1.APIResourceList
+	select {
+	case <-ctx.Done():
+		return false, fmt.Errorf("kustomization CRD probe cancelled: %w", ctx.Err())
+	case r := <-resultCh:
+		if r.err != nil {
+			if apierrors.IsNotFound(r.err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("list server resources for %s: %w", gv, r.err)
+		}
+		list = r.list
+	}
+
+	for _, res := range list.APIResources {
+		if res.Name == KustomizationGVR.Resource {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// KustomizationWatcher watches Kustomization events for the
+// configured component set, maps them via status.MapKustomization,
+// and routes the (prev, next) transition through its own Debouncer
+// before writing to the store. Status mapping rules and the debounce
+// protocol live in internal/status/.
+//
+// In-cluster RBAC: needs get, list, watch on
+// kustomize.toolkit.fluxcd.io/v1/kustomizations. The Helm chart (#24)
+// will ship the appropriate ClusterRole.
+//
+// Cache-sync failures (e.g., forbidden list/watch) currently abort
+// the watcher and propagate up through serveCmd's errCh, mirroring
+// the existing HelmRelease/Application/Deployment behavior. Issue
+// #58 tracks switching to log-and-degrade across all four watchers.
+type KustomizationWatcher struct {
+	client  dynamic.Interface
+	store   store.Store
+	watched map[types.NamespacedName]config.Spec
+	logger  *slog.Logger
+	window  time.Duration
+	clk     clock.WithDelayedExecution
+	gvr     schema.GroupVersionResource
+
+	lister    cache.GenericLister
+	debouncer *status.Debouncer
+	ctx       context.Context
+
+	syncedCh   chan struct{}
+	syncedOnce sync.Once
+}
+
+// NewKustomizationWatcher mirrors NewHelmReleaseWatcher: it filters
+// specs to Kind == "Kustomization" and builds the lookup map. An
+// empty filtered set is valid — the watcher runs but writes nothing.
+// window=0 disables debouncing (Apply writes immediately). clk=nil
+// defaults to clock.RealClock{}. A nil logger falls back to
+// slog.Default().
+func NewKustomizationWatcher(
+	client dynamic.Interface,
+	st store.Store,
+	specs []config.Spec,
+	logger *slog.Logger,
+	window time.Duration,
+	clk clock.WithDelayedExecution,
+	gvr schema.GroupVersionResource,
+) *KustomizationWatcher {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if clk == nil {
+		clk = clock.RealClock{}
+	}
+	watched := make(map[types.NamespacedName]config.Spec)
+	for _, s := range specs {
+		if s.Kind != "Kustomization" {
+			continue
+		}
+		key := types.NamespacedName{Namespace: s.Namespace, Name: s.Name}
+		watched[key] = s
+	}
+	return &KustomizationWatcher{
+		client:   client,
+		store:    st,
+		watched:  watched,
+		logger:   logger.With("watcher", "kustomization"),
+		window:   window,
+		clk:      clk,
+		gvr:      gvr,
+		syncedCh: make(chan struct{}),
+	}
+}
+
+// Synced returns a channel that is closed once the watcher's informer
+// cache has finished its initial list/watch sync.
+func (w *KustomizationWatcher) Synced() <-chan struct{} {
+	return w.syncedCh
+}
+
+// Start runs the dynamic informer until ctx is cancelled. Blocks; the
+// caller is expected to launch it in its own goroutine.
+func (w *KustomizationWatcher) Start(ctx context.Context) error {
+	w.ctx = ctx
+	factory := dynamicinformer.NewDynamicSharedInformerFactory(w.client, 0)
+	informer := factory.ForResource(w.gvr).Informer()
+	w.lister = factory.ForResource(w.gvr).Lister()
+	w.debouncer = status.NewDebouncer(w.window, w.clk, w.retry)
+	defer w.debouncer.Stop()
+
+	if _, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			u, ok := obj.(*unstructured.Unstructured)
+			if !ok {
+				return
+			}
+			w.handle(ctx, u)
+		},
+		UpdateFunc: func(_, newObj interface{}) {
+			u, ok := newObj.(*unstructured.Unstructured)
+			if !ok {
+				return
+			}
+			w.handle(ctx, u)
+		},
+		DeleteFunc: func(_ interface{}) {
+			// Last status sticks. Stale pending state for a deleted
+			// object is cleared by the retry callback's lister-miss
+			// branch when the timer fires.
+		},
+	}); err != nil {
+		return fmt.Errorf("watcher: add event handler: %w", err)
+	}
+
+	factory.Start(ctx.Done())
+	if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
+		if ctx.Err() != nil {
+			return nil
+		}
+		return errors.New("watcher: kustomization cache sync failed")
+	}
+	w.syncedOnce.Do(func() { close(w.syncedCh) })
+	w.logger.Info("synced", "watched", len(w.watched))
+
+	<-ctx.Done()
+	return nil
+}
+
+func (w *KustomizationWatcher) handle(ctx context.Context, u *unstructured.Unstructured) {
+	key := types.NamespacedName{Namespace: u.GetNamespace(), Name: u.GetName()}
+	spec, ok := w.watched[key]
+	if !ok {
+		return
+	}
+
+	next := status.MapKustomization(u)
+	id := (component.Component{
+		Kind: "Kustomization", Namespace: spec.Namespace, Name: spec.Name,
+	}).ID()
+
+	prev, err := w.fetchPrev(ctx, id)
+	if err != nil {
+		w.logger.Error("get prev failed", "err", err, "id", id)
+		return
+	}
+
+	write, finalStatus, retryAfter := w.debouncer.Apply(id, prev, next, w.clk.Now())
+	if write {
+		c := component.Component{
+			Kind:        "Kustomization",
+			Namespace:   spec.Namespace,
+			Name:        spec.Name,
+			DisplayName: displayNameOrName(spec),
+			Status:      finalStatus,
+		}
+		if err := w.store.UpsertComponent(ctx, c); err != nil {
+			w.logger.Error("upsert failed",
+				"err", err,
+				"id", id,
+				"status", string(finalStatus),
+			)
+			return
+		}
+		w.logger.Info("reconciled", "id", id, "status", string(finalStatus))
+		return
+	}
+	if retryAfter > 0 {
+		w.logger.Debug("debounced",
+			"id", id,
+			"prev", string(prev),
+			"next", string(next),
+			"retry_after", retryAfter,
+		)
+	}
+}
+
+func (w *KustomizationWatcher) fetchPrev(ctx context.Context, id string) (component.Status, error) {
+	got, err := w.store.GetComponent(ctx, id)
+	if errors.Is(err, store.ErrNotFound) {
+		return component.StatusUnknown, nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return got.Status, nil
+}
+
+// retry is the Debouncer's per-key callback. id format is
+// "Kustomization/<namespace>/<name>" — the canonical Component ID.
+func (w *KustomizationWatcher) retry(id string) {
+	parts := strings.SplitN(id, "/", 3)
+	if len(parts) != 3 || parts[0] != "Kustomization" {
+		return
+	}
+	obj, err := w.lister.ByNamespace(parts[1]).Get(parts[2])
+	if err != nil || obj == nil {
+		w.debouncer.Forget(id)
+		return
+	}
+	u, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		w.debouncer.Forget(id)
+		return
+	}
+	w.handle(w.ctx, u)
+}

--- a/internal/watcher/kustomization_test.go
+++ b/internal/watcher/kustomization_test.go
@@ -1,0 +1,392 @@
+package watcher
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/northwatchlabs/northwatch/internal/component"
+	"github.com/northwatchlabs/northwatch/internal/config"
+	"github.com/northwatchlabs/northwatch/internal/store"
+)
+
+// stubKsResourceDiscovery is the minimal kustomizationResourceDiscovery
+// impl used by the probe tests. The block channel lets the cancel
+// test exercise the ctx.Done() race without depending on a real
+// network round-trip.
+type stubKsResourceDiscovery struct {
+	list  *metav1.APIResourceList
+	err   error
+	block <-chan struct{}
+}
+
+func (s *stubKsResourceDiscovery) ServerResourcesForGroupVersion(string) (*metav1.APIResourceList, error) {
+	if s.block != nil {
+		<-s.block
+	}
+	return s.list, s.err
+}
+
+func TestKustomizationCRDPresentVia_ResourcePresent(t *testing.T) {
+	disc := &stubKsResourceDiscovery{list: &metav1.APIResourceList{
+		GroupVersion: KustomizationGVR.GroupVersion().String(),
+		APIResources: []metav1.APIResource{
+			{Name: KustomizationGVR.Resource},
+		},
+	}}
+	ok, err := kustomizationCRDPresentVia(context.Background(), disc)
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !ok {
+		t.Errorf("ok = false, want true (kustomizations resource present)")
+	}
+}
+
+func TestKustomizationCRDPresentVia_ResourceAbsent(t *testing.T) {
+	// Group/version registered but the kustomizations resource isn't
+	// in the resource list. Treat as absent.
+	disc := &stubKsResourceDiscovery{list: &metav1.APIResourceList{
+		GroupVersion: KustomizationGVR.GroupVersion().String(),
+		APIResources: []metav1.APIResource{
+			{Name: "somethingelse"},
+		},
+	}}
+	ok, err := kustomizationCRDPresentVia(context.Background(), disc)
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if ok {
+		t.Errorf("ok = true, want false (kustomizations resource missing)")
+	}
+}
+
+func TestKustomizationCRDPresentVia_GroupVersionNotFound(t *testing.T) {
+	// Non-Flux cluster: ServerResourcesForGroupVersion returns NotFound.
+	// Treat as absent, not error.
+	disc := &stubKsResourceDiscovery{err: apierrors.NewNotFound(
+		schema.GroupResource{Group: KustomizationGVR.Group, Resource: ""},
+		KustomizationGVR.GroupVersion().String(),
+	)}
+	ok, err := kustomizationCRDPresentVia(context.Background(), disc)
+	if err != nil {
+		t.Fatalf("err = %v, want nil (NotFound is clean absent)", err)
+	}
+	if ok {
+		t.Errorf("ok = true, want false on NotFound")
+	}
+}
+
+func TestKustomizationCRDPresentVia_DiscoveryError(t *testing.T) {
+	wantErr := errors.New("apiserver unreachable")
+	disc := &stubKsResourceDiscovery{err: wantErr}
+	ok, err := kustomizationCRDPresentVia(context.Background(), disc)
+	if err == nil || !errors.Is(err, wantErr) {
+		t.Errorf("err = %v, want wrap of %v", err, wantErr)
+	}
+	if ok {
+		t.Errorf("ok = true, want false on error")
+	}
+}
+
+func TestKustomizationCRDPresentVia_CtxCancelled(t *testing.T) {
+	block := make(chan struct{})
+	defer close(block)
+	disc := &stubKsResourceDiscovery{block: block}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan struct{})
+	var (
+		ok  bool
+		err error
+	)
+	go func() {
+		ok, err = kustomizationCRDPresentVia(ctx, disc)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("probe did not return after ctx cancel within 2s")
+	}
+	if err == nil || !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want wrap of context.Canceled", err)
+	}
+	if ok {
+		t.Errorf("ok = true, want false on cancel")
+	}
+}
+
+// newDynamicClientKs returns a fake dynamic client wired with the
+// Kustomization GVR → list-kind mapping that dynamicinformer needs.
+func newDynamicClientKs() *dynfake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+	listKinds := map[schema.GroupVersionResource]string{
+		KustomizationGVR: "KustomizationList",
+	}
+	return dynfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
+}
+
+func newKustomization(ns, name, readyStatus, readyReason string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(KustomizationGVR.GroupVersion().WithKind("Kustomization"))
+	u.SetNamespace(ns)
+	u.SetName(name)
+	if readyStatus != "" {
+		conds := []interface{}{
+			map[string]interface{}{
+				"type":   "Ready",
+				"status": readyStatus,
+				"reason": readyReason,
+			},
+		}
+		_ = unstructured.SetNestedSlice(u.Object, conds, "status", "conditions")
+	}
+	return u
+}
+
+func startKustomizationWatcher(t *testing.T, cs dynamic.Interface, rs store.Store, specs []config.Spec) func() {
+	t.Helper()
+	w := NewKustomizationWatcher(cs, rs, specs, quietLogger(), 0, nil, KustomizationGVR)
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- w.Start(ctx) }()
+
+	select {
+	case <-w.Synced():
+	case <-time.After(2 * time.Second):
+		cancel()
+		select {
+		case err := <-errCh:
+			t.Fatalf("watcher did not sync within 2s (Start returned %v)", err)
+		case <-time.After(2 * time.Second):
+			t.Fatal("watcher did not sync within 2s and did not exit after cancel")
+		}
+	}
+
+	return func() {
+		cancel()
+		select {
+		case err := <-errCh:
+			if err != nil {
+				t.Errorf("Start returned error: %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("watcher did not stop within 2s of cancel")
+		}
+	}
+}
+
+func TestKustomizationWatcher_ReadyTransitions(t *testing.T) {
+	cs := newDynamicClientKs()
+	rs := newRecordStore()
+	specs := []config.Spec{{
+		Kind: "Kustomization", Namespace: "flux-system", Name: "infra", DisplayName: "Infra",
+	}}
+	stop := startKustomizationWatcher(t, cs, rs, specs)
+	defer stop()
+
+	ctx := context.Background()
+	res := cs.Resource(KustomizationGVR).Namespace("flux-system")
+
+	// operational: Ready=True
+	if _, err := res.Create(ctx, newKustomization("flux-system", "infra", "True", "ReconciliationSucceeded"), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	rs.waitForCalls(t, 1)
+	if got := rs.snapshot()[0].Status; got != component.StatusOperational {
+		t.Errorf("[0] status = %q, want %q", got, component.StatusOperational)
+	}
+
+	// degraded: Ready=False, reason=Progressing
+	cur, err := res.Get(ctx, "infra", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	_ = unstructured.SetNestedSlice(cur.Object, []interface{}{
+		map[string]interface{}{"type": "Ready", "status": "False", "reason": "Progressing"},
+	}, "status", "conditions")
+	if _, err := res.Update(ctx, cur, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("update degraded: %v", err)
+	}
+	rs.waitForCalls(t, 2)
+	if got := rs.snapshot()[1].Status; got != component.StatusDegraded {
+		t.Errorf("[1] status = %q, want %q", got, component.StatusDegraded)
+	}
+
+	// down: Ready=False, reason=BuildFailed (real kustomize-controller reason)
+	cur, _ = res.Get(ctx, "infra", metav1.GetOptions{})
+	_ = unstructured.SetNestedSlice(cur.Object, []interface{}{
+		map[string]interface{}{"type": "Ready", "status": "False", "reason": "BuildFailed"},
+	}, "status", "conditions")
+	if _, err := res.Update(ctx, cur, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("update down: %v", err)
+	}
+	rs.waitForCalls(t, 3)
+	if got := rs.snapshot()[2].Status; got != component.StatusDown {
+		t.Errorf("[2] status = %q, want %q", got, component.StatusDown)
+	}
+
+	// operational again
+	cur, _ = res.Get(ctx, "infra", metav1.GetOptions{})
+	_ = unstructured.SetNestedSlice(cur.Object, []interface{}{
+		map[string]interface{}{"type": "Ready", "status": "True", "reason": "ReconciliationSucceeded"},
+	}, "status", "conditions")
+	if _, err := res.Update(ctx, cur, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("update operational: %v", err)
+	}
+	rs.waitForCalls(t, 4)
+	if got := rs.snapshot()[3].Status; got != component.StatusOperational {
+		t.Errorf("[3] status = %q, want %q", got, component.StatusOperational)
+	}
+}
+
+func TestKustomizationWatcher_UnwatchedIgnored(t *testing.T) {
+	cs := newDynamicClientKs()
+	rs := newRecordStore()
+	specs := []config.Spec{{
+		Kind: "Kustomization", Namespace: "flux-system", Name: "watched",
+	}}
+	stop := startKustomizationWatcher(t, cs, rs, specs)
+	defer stop()
+
+	ctx := context.Background()
+	res := cs.Resource(KustomizationGVR)
+
+	if _, err := res.Namespace("flux-system").Create(ctx, newKustomization("flux-system", "other", "True", "ok"), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create other: %v", err)
+	}
+	if _, err := res.Namespace("apps").Create(ctx, newKustomization("apps", "watched", "True", "ok"), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create other-ns: %v", err)
+	}
+	if _, err := res.Namespace("flux-system").Create(ctx, newKustomization("flux-system", "watched", "True", "ok"), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create watched: %v", err)
+	}
+
+	rs.waitForCalls(t, 1)
+	rs.assertCountStable(t, 1)
+	got := rs.snapshot()[0]
+	if got.Name != "watched" || got.Namespace != "flux-system" {
+		t.Errorf("upserted wrong component: %+v", got)
+	}
+}
+
+func TestKustomizationWatcher_StatusUnchangedNoOp(t *testing.T) {
+	cs := newDynamicClientKs()
+	rs := newRecordStore()
+	specs := []config.Spec{{
+		Kind: "Kustomization", Namespace: "flux-system", Name: "infra",
+	}}
+	stop := startKustomizationWatcher(t, cs, rs, specs)
+	defer stop()
+
+	ctx := context.Background()
+	res := cs.Resource(KustomizationGVR).Namespace("flux-system")
+	if _, err := res.Create(ctx, newKustomization("flux-system", "infra", "True", "ok"), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	rs.waitForCalls(t, 1)
+
+	// Same Ready=True, different reason — status is still operational,
+	// so this should not produce a second upsert.
+	cur, _ := res.Get(ctx, "infra", metav1.GetOptions{})
+	_ = unstructured.SetNestedSlice(cur.Object, []interface{}{
+		map[string]interface{}{"type": "Ready", "status": "True", "reason": "ReconciliationSucceeded"},
+	}, "status", "conditions")
+	if _, err := res.Update(ctx, cur, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("update same: %v", err)
+	}
+	rs.assertCountStable(t, 1)
+
+	// Real change → upsert.
+	cur, _ = res.Get(ctx, "infra", metav1.GetOptions{})
+	_ = unstructured.SetNestedSlice(cur.Object, []interface{}{
+		map[string]interface{}{"type": "Ready", "status": "False", "reason": "BuildFailed"},
+	}, "status", "conditions")
+	if _, err := res.Update(ctx, cur, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("update changed: %v", err)
+	}
+	rs.waitForCalls(t, 2)
+}
+
+func TestKustomizationWatcher_DeleteLeavesStatus(t *testing.T) {
+	cs := newDynamicClientKs()
+	rs := newRecordStore()
+	specs := []config.Spec{{
+		Kind: "Kustomization", Namespace: "flux-system", Name: "infra",
+	}}
+	stop := startKustomizationWatcher(t, cs, rs, specs)
+	defer stop()
+
+	ctx := context.Background()
+	res := cs.Resource(KustomizationGVR).Namespace("flux-system")
+	if _, err := res.Create(ctx, newKustomization("flux-system", "infra", "False", "BuildFailed"), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	rs.waitForCalls(t, 1)
+	if got := rs.snapshot()[0].Status; got != component.StatusDown {
+		t.Fatalf("initial status = %q, want %q", got, component.StatusDown)
+	}
+
+	if err := res.Delete(ctx, "infra", metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	rs.assertCountStable(t, 1)
+	if got := rs.snapshot()[0].Status; got != component.StatusDown {
+		t.Errorf("recorded status after delete = %q, want %q", got, component.StatusDown)
+	}
+}
+
+func TestKustomizationWatcher_CrossKindIsolation(t *testing.T) {
+	cs := newDynamicClientKs()
+	rs := newRecordStore()
+	// Spec with matching (ns, name) but Kind=HelmRelease must NOT
+	// match a Kustomization event.
+	specs := []config.Spec{{
+		Kind: "HelmRelease", Namespace: "flux-system", Name: "infra",
+	}}
+	stop := startKustomizationWatcher(t, cs, rs, specs)
+	defer stop()
+
+	ctx := context.Background()
+	res := cs.Resource(KustomizationGVR).Namespace("flux-system")
+	if _, err := res.Create(ctx, newKustomization("flux-system", "infra", "True", "ok"), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	rs.assertCountStable(t, 0)
+}
+
+func TestKustomizationWatcher_DisplayNamePropagation(t *testing.T) {
+	cs := newDynamicClientKs()
+	rs := newRecordStore()
+	specs := []config.Spec{{
+		Kind: "Kustomization", Namespace: "flux-system", Name: "infra", DisplayName: "Infra Bundle",
+	}}
+	stop := startKustomizationWatcher(t, cs, rs, specs)
+	defer stop()
+
+	ctx := context.Background()
+	res := cs.Resource(KustomizationGVR).Namespace("flux-system")
+	if _, err := res.Create(ctx, newKustomization("flux-system", "infra", "True", "ok"), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	rs.waitForCalls(t, 1)
+	got := rs.snapshot()[0]
+	if got.DisplayName != "Infra Bundle" {
+		t.Errorf("DisplayName = %q, want %q", got.DisplayName, "Infra Bundle")
+	}
+	if got.Kind != "Kustomization" {
+		t.Errorf("Kind = %q, want %q", got.Kind, "Kustomization")
+	}
+}


### PR DESCRIPTION
## Summary

- Add a `KustomizationWatcher` mirroring the existing HelmRelease watcher: dynamic informer over `kustomize.toolkit.fluxcd.io/v1.Kustomization`, Ready-condition mapping, debounce + lister-miss retry
- Extract a shared `mapReadyCondition` helper; `MapKustomization` and `MapHelmRelease` are now thin delegates so #57 can swap in a kstatus-aware implementation symmetrically
- Probe the Kustomization CRD via `ServerResourcesForGroupVersion` (single stable v1 — no multi-version fallback) and skip the watcher with `"Flux Kustomize CRDs not present, skipping kustomization watcher"` when absent
- Allow `kind: Kustomization` in `northwatch.yaml` and update the validation error message
- Wire into `serveCmd` after the existing watcher block; bump `errCh` buffer 4 → 5
- README gains a copy-paste "Watch a Flux Kustomization" recipe pointed at `stefanprodan/podinfo`'s `/kustomize/` path; example config gains a Kustomization placeholder

Closes #50

## Test plan

- [x] `go test ./... -count=1` — all packages PASS
- [x] `go test ./... -race -count=1` — no data races
- [x] `gofmt -l .` empty; `go vet ./...` clean
- [x] Probe unit tests: present, absent-resource, group-version-NotFound, discovery-error, ctx-cancelled
- [x] Watcher unit tests: ReadyTransitions (operational → degraded → down → operational), UnwatchedIgnored, StatusUnchangedNoOp, DeleteLeavesStatus, CrossKindIsolation, DisplayNamePropagation
- [x] Mapper unit tests: Ready=True/False+Progressing/False+BuildFailed/False+HealthCheckFailed/missing/Unknown/no-conditions
- [x] Smoke test: `serve --no-cluster --config examples/basic/northwatch.yaml` boots cleanly, syncs 4 components, exits gracefully
- [x] In-cluster smoke test: kind cluster with Flux source+kustomize controllers; podinfo Kustomization renders `operational`; patching `spec.path` to a missing dir flipped it to `down` (reason `ArtifactFailed`); on a plain kind cluster (no Flux) all three CRD-absent log lines fired exactly as spec'd and the Kustomization component shows `unknown`