### PR TITLE
Add kstatus-aware status mapper for HelmRelease and Kustomization

### DIFF
--- a/internal/status/mapper.go
+++ b/internal/status/mapper.go
@@ -8,67 +8,121 @@ import (
 	"github.com/northwatchlabs/northwatch/internal/component"
 )
 
-// MapHelmRelease returns the component status for a Flux HelmRelease
-// based on status.conditions[type=Ready].
+// MapHelmRelease returns the component status for a Flux HelmRelease.
+// Honors the kstatus condition triplet (Stalled, Ready, Reconciling)
+// with per-condition observedGeneration freshness. Precedence (first
+// trusted match wins):
 //
-//   - Ready=True                       → operational
-//   - Ready=False, reason=Progressing  → degraded
-//   - Ready=False, other reason        → down
-//   - Ready missing/Unknown            → unknown
+//   - Stalled=True (fresh)                       → down
+//   - Ready=True (fresh)                         → operational
+//   - Ready=False, reason=Progressing (fresh)    → degraded
+//   - Ready=False, other reason (fresh)          → down
+//   - Reconciling=True (fresh)                   → degraded
+//   - otherwise                                  → unknown
+//
+// "Fresh" means observedGeneration == metadata.generation; stale
+// conditions are ignored.
 func MapHelmRelease(u *unstructured.Unstructured) component.Status {
-	return mapReadyCondition(u)
+	return mapFluxConditions(u)
 }
 
 // MapKustomization returns the component status for a Flux
-// Kustomization (kustomize.toolkit.fluxcd.io/v1) based on
-// status.conditions[type=Ready].
+// Kustomization (kustomize.toolkit.fluxcd.io/v1). Honors the kstatus
+// condition triplet (Stalled, Ready, Reconciling) with per-condition
+// observedGeneration freshness. Precedence (first trusted match
+// wins):
 //
-//   - Ready=True                       → operational
-//   - Ready=False, reason=Progressing  → degraded
-//   - Ready=False, other reason        → down
-//   - Ready missing/Unknown            → unknown
+//   - Stalled=True (fresh)                       → down
+//   - Ready=True (fresh)                         → operational
+//   - Ready=False, reason=Progressing (fresh)    → degraded
+//   - Ready=False, other reason (fresh)          → down
+//   - Reconciling=True (fresh)                   → degraded
+//   - otherwise                                  → unknown
 //
-// kustomize-controller also surfaces separate Reconciling and Stalled
-// conditions (kstatus). Inspecting those is tracked separately (#57)
-// and must land symmetrically in MapHelmRelease and MapKustomization.
+// "Fresh" means observedGeneration == metadata.generation; stale
+// conditions are ignored.
 func MapKustomization(u *unstructured.Unstructured) component.Status {
-	return mapReadyCondition(u)
+	return mapFluxConditions(u)
 }
 
-// mapReadyCondition is the shared Ready-condition mapper used by
-// MapHelmRelease and MapKustomization. Both Flux controllers report
-// reconcile state through status.conditions[type=Ready] with the
-// same shape: status ∈ {True,False,Unknown}, reason ∈ {Progressing,
-// <controller-specific failure reasons>...}. Keep the two exported
-// functions as thin delegates so a future kstatus-aware mapper (see
-// #57) can swap the implementation in one place.
-func mapReadyCondition(u *unstructured.Unstructured) component.Status {
-	conds, found, err := unstructured.NestedSlice(u.Object, "status", "conditions")
-	if err != nil || !found {
-		return component.StatusUnknown
+// asInt64 tolerantly decodes a value from an unstructured map. JSON
+// deserialization into unstructured can produce either int64 or
+// float64 for numeric fields depending on the code path, so accept
+// both. Missing or unrecognized types decode as 0.
+func asInt64(v interface{}) int64 {
+	switch x := v.(type) {
+	case int64:
+		return x
+	case float64:
+		return int64(x)
+	case int:
+		return int64(x)
 	}
+	return 0
+}
+
+// findCondition returns the status, reason, and observedGeneration of
+// the first entry in status.conditions whose type matches condType.
+// observedGenPresent indicates whether the observedGeneration field
+// was explicitly set on the matched condition — callers must check
+// this to avoid treating a missing field's zero value as a legitimate
+// generation. Returns ("", "", 0, false, false) if no matching entry
+// is present or the slice is malformed.
+func findCondition(conds []interface{}, condType string) (status, reason string, observedGen int64, observedGenPresent bool, found bool) {
 	for _, c := range conds {
 		m, ok := c.(map[string]interface{})
 		if !ok {
 			continue
 		}
-		if t, _ := m["type"].(string); t != "Ready" {
+		t, _ := m["type"].(string)
+		if t != condType {
 			continue
 		}
 		s, _ := m["status"].(string)
-		switch s {
+		r, _ := m["reason"].(string)
+		ogv, ogPresent := m["observedGeneration"]
+		og := asInt64(ogv)
+		return s, r, og, ogPresent, true
+	}
+	return "", "", 0, false, false
+}
+
+// mapFluxConditions is the shared kstatus-aware mapper used by
+// MapHelmRelease and MapKustomization. Each of Stalled, Ready, and
+// Reconciling is checked for freshness independently — a condition
+// is trusted iff its observedGeneration matches the resource's
+// metadata.generation. Stale conditions are ignored as if absent.
+// See MapHelmRelease for the full precedence table.
+func mapFluxConditions(u *unstructured.Unstructured) component.Status {
+	conds, found, err := unstructured.NestedSlice(u.Object, "status", "conditions")
+	if err != nil || !found {
+		return component.StatusUnknown
+	}
+
+	gen := u.GetGeneration()
+
+	if s, _, og, ogP, ok := findCondition(conds, "Stalled"); ok && ogP && og == gen && s == "True" {
+		return component.StatusDown
+	}
+
+	readyStatus, readyReason, readyOG, readyOGP, hasReady := findCondition(conds, "Ready")
+	if hasReady && readyOGP && readyOG == gen {
+		switch readyStatus {
 		case "True":
 			return component.StatusOperational
 		case "False":
-			reason, _ := m["reason"].(string)
-			if reason == "Progressing" {
+			if readyReason == "Progressing" {
 				return component.StatusDegraded
 			}
 			return component.StatusDown
-		default:
-			return component.StatusUnknown
 		}
+		// Ready=Unknown or unrecognized: fall through to Reconciling.
 	}
+
+	if s, _, og, ogP, ok := findCondition(conds, "Reconciling"); ok && ogP && og == gen && s == "True" {
+		return component.StatusDegraded
+	}
+
 	return component.StatusUnknown
 }
 

--- a/internal/status/mapper_test.go
+++ b/internal/status/mapper_test.go
@@ -49,6 +49,83 @@ func TestMapHelmRelease(t *testing.T) {
 			hr:   newHelmRelease(nil),
 			want: component.StatusUnknown,
 		},
+		{
+			name: "Stalled=True (fresh) overrides Ready=False/BuildFailed → down",
+			hr: helmReleaseWithGeneration(1,
+				condition{condType: "Stalled", status: "True", reason: "RetriesExhausted", observedGen: int64(1)},
+				condition{condType: "Ready", status: "False", reason: "BuildFailed", observedGen: int64(1)},
+			),
+			want: component.StatusDown,
+		},
+		{
+			name: "Reconciling=True (fresh) with Ready=True → operational (routine re-reconcile)",
+			hr: helmReleaseWithGeneration(1,
+				condition{condType: "Reconciling", status: "True", reason: "Progressing", observedGen: int64(1)},
+				condition{condType: "Ready", status: "True", observedGen: int64(1)},
+			),
+			want: component.StatusOperational,
+		},
+		{
+			name: "Reconciling=True (fresh) with Ready=Unknown → degraded",
+			hr: helmReleaseWithGeneration(1,
+				condition{condType: "Reconciling", status: "True", reason: "Progressing", observedGen: int64(1)},
+				condition{condType: "Ready", status: "Unknown", observedGen: int64(1)},
+			),
+			want: component.StatusDegraded,
+		},
+		{
+			name: "Reconciling=True (fresh) with Ready=False/InstallFailed → down (trusted Ready=False/other wins)",
+			hr: helmReleaseWithGeneration(1,
+				condition{condType: "Reconciling", status: "True", reason: "Progressing", observedGen: int64(1)},
+				condition{condType: "Ready", status: "False", reason: "InstallFailed", observedGen: int64(1)},
+			),
+			want: component.StatusDown,
+		},
+		{
+			name: "Stalled=True AND Reconciling=True (both fresh) → down (Stalled wins)",
+			hr: helmReleaseWithGeneration(1,
+				condition{condType: "Stalled", status: "True", reason: "InstallFailed", observedGen: int64(1)},
+				condition{condType: "Reconciling", status: "True", reason: "Progressing", observedGen: int64(1)},
+				condition{condType: "Ready", status: "False", reason: "InstallFailed", observedGen: int64(1)},
+			),
+			want: component.StatusDown,
+		},
+		{
+			name: "Stale Ready (gen=2, observedGen=1) Ready=True → unknown (freshness)",
+			hr: helmReleaseWithGeneration(2,
+				condition{condType: "Ready", status: "True", observedGen: int64(1)},
+			),
+			want: component.StatusUnknown,
+		},
+		{
+			name: "Stale Stalled + stale Ready (gen=2, all observedGen=1) → unknown",
+			hr: helmReleaseWithGeneration(2,
+				condition{condType: "Stalled", status: "True", reason: "InstallFailed", observedGen: int64(1)},
+				condition{condType: "Ready", status: "True", observedGen: int64(1)},
+			),
+			want: component.StatusUnknown,
+		},
+		{
+			name: "Ready missing observedGeneration, gen=1, Ready=True → unknown (stale)",
+			hr: helmReleaseWithGeneration(1,
+				condition{condType: "Ready", status: "True"},
+			),
+			want: component.StatusUnknown,
+		},
+		{
+			name: "observedGeneration as float64, gen=1, Ready=True → operational (tolerant decode)",
+			hr: helmReleaseWithGeneration(1,
+				condition{condType: "Ready", status: "True", observedGen: float64(1)},
+			),
+			want: component.StatusOperational,
+		},
+		{
+			name: "Fresh Stalled=True with Ready missing → down (per-condition freshness)",
+			hr: helmReleaseWithGeneration(1,
+				condition{condType: "Stalled", status: "True", reason: "RetriesExhausted", observedGen: int64(1)},
+			),
+			want: component.StatusDown,
+		},
 	}
 
 	for _, tc := range tests {
@@ -104,6 +181,83 @@ func TestMapKustomization(t *testing.T) {
 			ks:   newKustomization(nil),
 			want: component.StatusUnknown,
 		},
+		{
+			name: "Stalled=True (fresh) overrides Ready=False/BuildFailed → down",
+			ks: kustomizationWithGeneration(1,
+				condition{condType: "Stalled", status: "True", reason: "RetriesExhausted", observedGen: int64(1)},
+				condition{condType: "Ready", status: "False", reason: "BuildFailed", observedGen: int64(1)},
+			),
+			want: component.StatusDown,
+		},
+		{
+			name: "Reconciling=True (fresh) with Ready=True → operational (routine re-reconcile)",
+			ks: kustomizationWithGeneration(1,
+				condition{condType: "Reconciling", status: "True", reason: "Progressing", observedGen: int64(1)},
+				condition{condType: "Ready", status: "True", observedGen: int64(1)},
+			),
+			want: component.StatusOperational,
+		},
+		{
+			name: "Reconciling=True (fresh) with Ready=Unknown → degraded",
+			ks: kustomizationWithGeneration(1,
+				condition{condType: "Reconciling", status: "True", reason: "Progressing", observedGen: int64(1)},
+				condition{condType: "Ready", status: "Unknown", observedGen: int64(1)},
+			),
+			want: component.StatusDegraded,
+		},
+		{
+			name: "Reconciling=True (fresh) with Ready=False/BuildFailed → down (trusted Ready=False/other wins)",
+			ks: kustomizationWithGeneration(1,
+				condition{condType: "Reconciling", status: "True", reason: "Progressing", observedGen: int64(1)},
+				condition{condType: "Ready", status: "False", reason: "BuildFailed", observedGen: int64(1)},
+			),
+			want: component.StatusDown,
+		},
+		{
+			name: "Stalled=True AND Reconciling=True (both fresh) → down (Stalled wins)",
+			ks: kustomizationWithGeneration(1,
+				condition{condType: "Stalled", status: "True", reason: "BuildFailed", observedGen: int64(1)},
+				condition{condType: "Reconciling", status: "True", reason: "Progressing", observedGen: int64(1)},
+				condition{condType: "Ready", status: "False", reason: "BuildFailed", observedGen: int64(1)},
+			),
+			want: component.StatusDown,
+		},
+		{
+			name: "Stale Ready (gen=2, observedGen=1) Ready=True → unknown (freshness)",
+			ks: kustomizationWithGeneration(2,
+				condition{condType: "Ready", status: "True", observedGen: int64(1)},
+			),
+			want: component.StatusUnknown,
+		},
+		{
+			name: "Stale Stalled + stale Ready (gen=2, all observedGen=1) → unknown",
+			ks: kustomizationWithGeneration(2,
+				condition{condType: "Stalled", status: "True", reason: "BuildFailed", observedGen: int64(1)},
+				condition{condType: "Ready", status: "True", observedGen: int64(1)},
+			),
+			want: component.StatusUnknown,
+		},
+		{
+			name: "Ready missing observedGeneration, gen=1, Ready=True → unknown (stale)",
+			ks: kustomizationWithGeneration(1,
+				condition{condType: "Ready", status: "True"},
+			),
+			want: component.StatusUnknown,
+		},
+		{
+			name: "observedGeneration as float64, gen=1, Ready=True → operational (tolerant decode)",
+			ks: kustomizationWithGeneration(1,
+				condition{condType: "Ready", status: "True", observedGen: float64(1)},
+			),
+			want: component.StatusOperational,
+		},
+		{
+			name: "Fresh Stalled=True with Ready missing → down (per-condition freshness)",
+			ks: kustomizationWithGeneration(1,
+				condition{condType: "Stalled", status: "True", reason: "RetriesExhausted", observedGen: int64(1)},
+			),
+			want: component.StatusDown,
+		},
 	}
 
 	for _, tc := range tests {
@@ -116,19 +270,61 @@ func TestMapKustomization(t *testing.T) {
 	}
 }
 
-func kustomizationWithReady(readyStatus, reason string) *unstructured.Unstructured {
-	cond := map[string]interface{}{
-		"type":   "Ready",
-		"status": readyStatus,
+// condition is a tiny test-only shape for building unstructured
+// status.conditions entries. Empty reason is omitted. observedGen is
+// emitted as-is when non-nil — pass int64 or float64 to exercise the
+// mapper's tolerant numeric decoding.
+type condition struct {
+	condType    string
+	status      string
+	reason      string
+	observedGen interface{} // nil omits the field
+}
+
+func conditionsObject(conds ...condition) map[string]interface{} {
+	out := make([]interface{}, 0, len(conds))
+	for _, c := range conds {
+		m := map[string]interface{}{
+			"type":   c.condType,
+			"status": c.status,
+		}
+		if c.reason != "" {
+			m["reason"] = c.reason
+		}
+		if c.observedGen != nil {
+			m["observedGeneration"] = c.observedGen
+		}
+		out = append(out, m)
 	}
-	if reason != "" {
-		cond["reason"] = reason
-	}
-	return newKustomization(map[string]interface{}{
+	return map[string]interface{}{
 		"status": map[string]interface{}{
-			"conditions": []interface{}{cond},
+			"conditions": out,
 		},
-	})
+	}
+}
+
+func helmReleaseWithConditions(conds ...condition) *unstructured.Unstructured {
+	return newHelmRelease(conditionsObject(conds...))
+}
+
+func kustomizationWithConditions(conds ...condition) *unstructured.Unstructured {
+	return newKustomization(conditionsObject(conds...))
+}
+
+func helmReleaseWithGeneration(gen int64, conds ...condition) *unstructured.Unstructured {
+	u := helmReleaseWithConditions(conds...)
+	u.SetGeneration(gen)
+	return u
+}
+
+func kustomizationWithGeneration(gen int64, conds ...condition) *unstructured.Unstructured {
+	u := kustomizationWithConditions(conds...)
+	u.SetGeneration(gen)
+	return u
+}
+
+func kustomizationWithReady(readyStatus, reason string) *unstructured.Unstructured {
+	return kustomizationWithGeneration(1, condition{condType: "Ready", status: readyStatus, reason: reason, observedGen: int64(1)})
 }
 
 func newKustomization(obj map[string]interface{}) *unstructured.Unstructured {
@@ -147,18 +343,7 @@ func newKustomization(obj map[string]interface{}) *unstructured.Unstructured {
 }
 
 func helmReleaseWithReady(readyStatus, reason string) *unstructured.Unstructured {
-	cond := map[string]interface{}{
-		"type":   "Ready",
-		"status": readyStatus,
-	}
-	if reason != "" {
-		cond["reason"] = reason
-	}
-	return newHelmRelease(map[string]interface{}{
-		"status": map[string]interface{}{
-			"conditions": []interface{}{cond},
-		},
-	})
+	return helmReleaseWithGeneration(1, condition{condType: "Ready", status: readyStatus, reason: reason, observedGen: int64(1)})
 }
 
 func newHelmRelease(obj map[string]interface{}) *unstructured.Unstructured {

--- a/internal/watcher/helmrelease_test.go
+++ b/internal/watcher/helmrelease_test.go
@@ -45,12 +45,14 @@ func newHelmRelease(ns, name, readyStatus, readyReason string) *unstructured.Uns
 	u.SetGroupVersionKind(helmReleaseV2GVR.GroupVersion().WithKind("HelmRelease"))
 	u.SetNamespace(ns)
 	u.SetName(name)
+	u.SetGeneration(1)
 	if readyStatus != "" {
 		conds := []interface{}{
 			map[string]interface{}{
-				"type":   "Ready",
-				"status": readyStatus,
-				"reason": readyReason,
+				"type":               "Ready",
+				"status":             readyStatus,
+				"reason":             readyReason,
+				"observedGeneration": int64(1),
 			},
 		}
 		_ = unstructured.SetNestedSlice(u.Object, conds, "status", "conditions")
@@ -117,7 +119,7 @@ func TestHelmReleaseWatcher_ReadyTransitions(t *testing.T) {
 		t.Fatalf("get: %v", err)
 	}
 	_ = unstructured.SetNestedSlice(cur.Object, []interface{}{
-		map[string]interface{}{"type": "Ready", "status": "False", "reason": "Progressing"},
+		map[string]interface{}{"type": "Ready", "status": "False", "reason": "Progressing", "observedGeneration": int64(1)},
 	}, "status", "conditions")
 	if _, err := res.Update(ctx, cur, metav1.UpdateOptions{}); err != nil {
 		t.Fatalf("update degraded: %v", err)
@@ -130,7 +132,7 @@ func TestHelmReleaseWatcher_ReadyTransitions(t *testing.T) {
 	// down: Ready=False, reason=InstallFailed
 	cur, _ = res.Get(ctx, "my-app", metav1.GetOptions{})
 	_ = unstructured.SetNestedSlice(cur.Object, []interface{}{
-		map[string]interface{}{"type": "Ready", "status": "False", "reason": "InstallFailed"},
+		map[string]interface{}{"type": "Ready", "status": "False", "reason": "InstallFailed", "observedGeneration": int64(1)},
 	}, "status", "conditions")
 	if _, err := res.Update(ctx, cur, metav1.UpdateOptions{}); err != nil {
 		t.Fatalf("update down: %v", err)
@@ -143,7 +145,7 @@ func TestHelmReleaseWatcher_ReadyTransitions(t *testing.T) {
 	// operational again: Ready=True
 	cur, _ = res.Get(ctx, "my-app", metav1.GetOptions{})
 	_ = unstructured.SetNestedSlice(cur.Object, []interface{}{
-		map[string]interface{}{"type": "Ready", "status": "True", "reason": "ReconciliationSucceeded"},
+		map[string]interface{}{"type": "Ready", "status": "True", "reason": "ReconciliationSucceeded", "observedGeneration": int64(1)},
 	}, "status", "conditions")
 	if _, err := res.Update(ctx, cur, metav1.UpdateOptions{}); err != nil {
 		t.Fatalf("update operational: %v", err)
@@ -204,7 +206,7 @@ func TestHelmReleaseWatcher_StatusUnchangedNoOp(t *testing.T) {
 	// so this should not produce a second upsert.
 	cur, _ := res.Get(ctx, "my-app", metav1.GetOptions{})
 	_ = unstructured.SetNestedSlice(cur.Object, []interface{}{
-		map[string]interface{}{"type": "Ready", "status": "True", "reason": "ReconciliationSucceeded"},
+		map[string]interface{}{"type": "Ready", "status": "True", "reason": "ReconciliationSucceeded", "observedGeneration": int64(1)},
 	}, "status", "conditions")
 	if _, err := res.Update(ctx, cur, metav1.UpdateOptions{}); err != nil {
 		t.Fatalf("update same: %v", err)
@@ -214,7 +216,7 @@ func TestHelmReleaseWatcher_StatusUnchangedNoOp(t *testing.T) {
 	// Real change → upsert.
 	cur, _ = res.Get(ctx, "my-app", metav1.GetOptions{})
 	_ = unstructured.SetNestedSlice(cur.Object, []interface{}{
-		map[string]interface{}{"type": "Ready", "status": "False", "reason": "InstallFailed"},
+		map[string]interface{}{"type": "Ready", "status": "False", "reason": "InstallFailed", "observedGeneration": int64(1)},
 	}, "status", "conditions")
 	if _, err := res.Update(ctx, cur, metav1.UpdateOptions{}); err != nil {
 		t.Fatalf("update changed: %v", err)

--- a/internal/watcher/kustomization_test.go
+++ b/internal/watcher/kustomization_test.go
@@ -143,12 +143,14 @@ func newKustomization(ns, name, readyStatus, readyReason string) *unstructured.U
 	u.SetGroupVersionKind(KustomizationGVR.GroupVersion().WithKind("Kustomization"))
 	u.SetNamespace(ns)
 	u.SetName(name)
+	u.SetGeneration(1)
 	if readyStatus != "" {
 		conds := []interface{}{
 			map[string]interface{}{
-				"type":   "Ready",
-				"status": readyStatus,
-				"reason": readyReason,
+				"type":               "Ready",
+				"status":             readyStatus,
+				"reason":             readyReason,
+				"observedGeneration": int64(1),
 			},
 		}
 		_ = unstructured.SetNestedSlice(u.Object, conds, "status", "conditions")
@@ -215,7 +217,7 @@ func TestKustomizationWatcher_ReadyTransitions(t *testing.T) {
 		t.Fatalf("get: %v", err)
 	}
 	_ = unstructured.SetNestedSlice(cur.Object, []interface{}{
-		map[string]interface{}{"type": "Ready", "status": "False", "reason": "Progressing"},
+		map[string]interface{}{"type": "Ready", "status": "False", "reason": "Progressing", "observedGeneration": int64(1)},
 	}, "status", "conditions")
 	if _, err := res.Update(ctx, cur, metav1.UpdateOptions{}); err != nil {
 		t.Fatalf("update degraded: %v", err)
@@ -228,7 +230,7 @@ func TestKustomizationWatcher_ReadyTransitions(t *testing.T) {
 	// down: Ready=False, reason=BuildFailed (real kustomize-controller reason)
 	cur, _ = res.Get(ctx, "infra", metav1.GetOptions{})
 	_ = unstructured.SetNestedSlice(cur.Object, []interface{}{
-		map[string]interface{}{"type": "Ready", "status": "False", "reason": "BuildFailed"},
+		map[string]interface{}{"type": "Ready", "status": "False", "reason": "BuildFailed", "observedGeneration": int64(1)},
 	}, "status", "conditions")
 	if _, err := res.Update(ctx, cur, metav1.UpdateOptions{}); err != nil {
 		t.Fatalf("update down: %v", err)
@@ -241,7 +243,7 @@ func TestKustomizationWatcher_ReadyTransitions(t *testing.T) {
 	// operational again
 	cur, _ = res.Get(ctx, "infra", metav1.GetOptions{})
 	_ = unstructured.SetNestedSlice(cur.Object, []interface{}{
-		map[string]interface{}{"type": "Ready", "status": "True", "reason": "ReconciliationSucceeded"},
+		map[string]interface{}{"type": "Ready", "status": "True", "reason": "ReconciliationSucceeded", "observedGeneration": int64(1)},
 	}, "status", "conditions")
 	if _, err := res.Update(ctx, cur, metav1.UpdateOptions{}); err != nil {
 		t.Fatalf("update operational: %v", err)
@@ -302,7 +304,7 @@ func TestKustomizationWatcher_StatusUnchangedNoOp(t *testing.T) {
 	// so this should not produce a second upsert.
 	cur, _ := res.Get(ctx, "infra", metav1.GetOptions{})
 	_ = unstructured.SetNestedSlice(cur.Object, []interface{}{
-		map[string]interface{}{"type": "Ready", "status": "True", "reason": "ReconciliationSucceeded"},
+		map[string]interface{}{"type": "Ready", "status": "True", "reason": "ReconciliationSucceeded", "observedGeneration": int64(1)},
 	}, "status", "conditions")
 	if _, err := res.Update(ctx, cur, metav1.UpdateOptions{}); err != nil {
 		t.Fatalf("update same: %v", err)
@@ -312,7 +314,7 @@ func TestKustomizationWatcher_StatusUnchangedNoOp(t *testing.T) {
 	// Real change → upsert.
 	cur, _ = res.Get(ctx, "infra", metav1.GetOptions{})
 	_ = unstructured.SetNestedSlice(cur.Object, []interface{}{
-		map[string]interface{}{"type": "Ready", "status": "False", "reason": "BuildFailed"},
+		map[string]interface{}{"type": "Ready", "status": "False", "reason": "BuildFailed", "observedGeneration": int64(1)},
 	}, "status", "conditions")
 	if _, err := res.Update(ctx, cur, metav1.UpdateOptions{}); err != nil {
 		t.Fatalf("update changed: %v", err)


### PR DESCRIPTION
## Summary
- Switches the Flux condition mapper from Ready-only to a kstatus-aware triplet (Stalled, Ready, Reconciling) with per-condition `observedGeneration` freshness, so a user-fixed spec no longer surfaces a stale `Stalled=True` as `down`.
- `Reconciling=True` no longer flips healthy resources to `degraded` during routine re-reconciles, and trusted `Ready=False/other-reason` continues to win over an in-flight retry — the dashboard answers "is it currently broken?" honestly.
- Symmetric coverage for `MapHelmRelease` and `MapKustomization`: 10 new table-driven cases per controller, covering each precedence rule plus stale/missing/float64 `observedGeneration` edges.

Closes #57

## Test plan
- [x] `go test ./internal/status/...` passes (existing + 20 new cases)
- [x] `go test ./...` passes (no caller regressions)
- [x] `go vet ./...` clean
- [x] `gofmt -l internal/status/` clean
- [x] Smoke-check in a live cluster: a stalled HelmRelease → fix the spec → dashboard moves off `down` before the next reconcile lands (verified in kind + Flux 2.8.7: dashboard transitioned `down → unknown → degraded → operational` immediately on spec edit; the `unknown` step is the freshness gate firing)
- [x] Smoke-check: routine 5-minute reconcile of a healthy HelmRelease/Kustomization does not flicker (verified in kind + Flux 2.8.7: zero status changes for a healthy HelmRelease across a 6-min observation window covering one natural reconcile cycle)