### PR TITLE
Add multi-stage Dockerfile and GHCR image publish workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# Keep the build context small and reproducible. Anything not needed
+# by `go build ./cmd/northwatch` or the embedded static assets should
+# be excluded.
+
+.git
+.github
+.agents
+.codex
+.claude
+
+# Local build artefacts.
+northwatch
+*.test
+*.out
+coverage.*
+dist/
+
+# Docs and examples — not used at build time.
+docs/
+examples/
+
+# Editor / OS noise.
+.idea/
+.vscode/
+.DS_Store
+*.swp
+
+# Local databases and dev state.
+*.db
+*.sqlite
+*.sqlite3
+
+# Node / Tailwind sources — compiled CSS is committed under
+# internal/ui/static/, so the source isn't needed in the image.
+node_modules/
+web/

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -1,0 +1,130 @@
+name: Build image
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    name: Build and publish container image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write   # push to ghcr.io
+      id-token: write   # cosign keyless OIDC
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4.0.0
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
+
+      - name: Build single-arch image for smoke test
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
+        with:
+          context: .
+          file: deploy/docker/Dockerfile
+          platforms: linux/amd64
+          load: true
+          tags: northwatch:smoke
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test image
+        run: |
+          set -euo pipefail
+          # Run the image with its default CMD ("serve") plus --no-cluster.
+          # No volumes — the baked-in default config and writable
+          # /var/lib/northwatch should be enough for /healthz to come up.
+          docker run -d --name nw -p 18080:8080 northwatch:smoke serve --no-cluster
+
+          # Assert non-root by image config (catches regressions where
+          # someone removes `USER nonroot`).
+          user=$(docker inspect --format '{{.Config.User}}' northwatch:smoke)
+          if [ "$user" != "nonroot:nonroot" ]; then
+            echo "::error::expected image User=nonroot:nonroot, got '$user'"
+            exit 1
+          fi
+          # And by the running process UID. `docker top` (no -o) prints
+          # a header row then the process row; UID is the first column.
+          uid=$(docker top nw | awk 'NR==2{print $1}')
+          if [ "$uid" != "65532" ]; then
+            echo "::error::expected container process UID=65532, got '$uid'"
+            docker top nw >&2 || true
+            exit 1
+          fi
+
+          # Wait for /healthz.
+          for i in $(seq 1 30); do
+            if curl -sfo /dev/null http://localhost:18080/healthz; then
+              echo "healthz OK after ${i}s (user=$user, uid=$uid)"
+              docker rm -f nw >/dev/null
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::smoke test failed; container logs follow" >&2
+          docker logs nw >&2 || true
+          docker rm -f nw >/dev/null || true
+          exit 1
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image metadata
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix=sha-
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
+        with:
+          context: .
+          file: deploy/docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+
+      - name: Sign published image
+        if: github.event_name != 'pull_request'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          for tag in $TAGS; do
+            cosign sign --yes "${tag}@${DIGEST}"
+          done

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,9 @@
 GO ?= go
 BIN := northwatch
 PKG := ./...
+IMAGE ?= northwatch:dev
 
-.PHONY: help build run test vet lint css clean
+.PHONY: help build run test vet lint css image clean
 
 help: ## Show this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make <target>\n\nTargets:\n"} /^[a-zA-Z_-]+:.*##/ { printf "  %-10s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
@@ -27,6 +28,9 @@ lint: ## Run golangci-lint (must be installed).
 css: ## Compile Tailwind CSS from web/input.css to internal/ui/static/style.css.
 	@command -v tailwindcss >/dev/null 2>&1 || { echo "tailwindcss not found in PATH; install standalone binary or via npm"; exit 1; }
 	tailwindcss -i web/input.css -o internal/ui/static/style.css --minify
+
+image: ## Build the container image (override with IMAGE=name:tag).
+	docker build -f deploy/docker/Dockerfile -t $(IMAGE) .
 
 clean: ## Remove build artifacts.
 	rm -f $(BIN)

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,0 +1,56 @@
+# syntax=docker/dockerfile:1.9
+
+# ---------- Stage 1: build ----------
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS build
+
+# Cross-compile target (set by buildx).
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /src
+
+# Cache module downloads independently of source changes.
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go mod download
+
+COPY . .
+
+# Pure-Go build (modernc.org/sqlite). Strip symbols and DWARF; trim
+# absolute paths from the binary for reproducibility.
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -trimpath -ldflags="-s -w" -o /out/northwatch ./cmd/northwatch
+
+# Empty skeleton dir copied into the runtime image so SQLite has a
+# writable home owned by UID 65532. Distroless has no shell/mkdir, so
+# the directory must be staged here.
+RUN mkdir -p /out/data
+
+# ---------- Stage 2: runtime ----------
+FROM gcr.io/distroless/static-debian12:nonroot
+
+COPY --from=build /out/northwatch /usr/local/bin/northwatch
+COPY --from=build --chown=65532:65532 /out/data /var/lib/northwatch
+COPY deploy/docker/northwatch.default.yaml /etc/northwatch/northwatch.yaml
+
+# Non-root by default (UID 65532 in distroless static nonroot).
+USER nonroot:nonroot
+WORKDIR /var/lib/northwatch
+
+# Default SQLite location, so `docker run <image>` works without
+# every caller having to set --db. Mount a volume at this path for
+# persistence across restarts.
+ENV NORTHWATCH_DB=/var/lib/northwatch/northwatch.db
+
+# Point at the baked-in default config so the entrypoint succeeds
+# without an external config mount. Override by mounting your own
+# YAML at /etc/northwatch/northwatch.yaml or by setting --config.
+ENV NORTHWATCH_CONFIG=/etc/northwatch/northwatch.yaml
+
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/local/bin/northwatch"]
+CMD ["serve"]

--- a/deploy/docker/northwatch.default.yaml
+++ b/deploy/docker/northwatch.default.yaml
@@ -1,0 +1,9 @@
+# Default NorthWatch config baked into the container image at
+# /etc/northwatch/northwatch.yaml. It exists so `docker run <image>`
+# starts cleanly out of the box. Replace it by mounting your own
+# YAML at the same path, or by overriding --config / NORTHWATCH_CONFIG.
+components:
+  - kind: Deployment
+    namespace: default
+    name: example
+    displayName: "Example Component (replace me)"


### PR DESCRIPTION
## Summary

- New multi-stage `deploy/docker/Dockerfile` builds a stripped, static
  binary in `golang:1.26-alpine` and copies it into
  `gcr.io/distroless/static-debian12:nonroot`. Pure-Go build
  (`CGO_ENABLED=0`) — `modernc.org/sqlite` doesn't need libc.
- Image ships everything needed to run out of the box:
  - Writable `/var/lib/northwatch` (UID 65532) as `WORKDIR`,
    `NORTHWATCH_DB=/var/lib/northwatch/northwatch.db` (mount a volume
    here for persistence).
  - Baked-in default config at `/etc/northwatch/northwatch.yaml`
    (`NORTHWATCH_CONFIG` points at it). `docker run <image>` works
    with no volumes; override by mounting your own YAML at the same
    path or via `--config`.
- New `.github/workflows/build-image.yaml` builds `linux/amd64` +
  `linux/arm64` via buildx + QEMU, runs an in-CI smoke test that
  asserts the image `Config.User` is `nonroot:nonroot`, the running
  process UID is `65532`, and `/healthz` returns 200 — all before
  any push. Publishes to `ghcr.io/northwatchlabs/northwatch` on
  `main` and `v*` tags and signs each tag with cosign keyless OIDC.
  PRs build + smoke-test only. All third-party actions pinned to
  40-char SHAs.
- New `.dockerignore` keeps the build context lean.
- New `make image` target for local builds (single-arch, host
  platform).

**Image size:** local single-arch image is **70.2 MB**, not the
issue's `< 30 MB` target. `modernc.org/sqlite` (~12 MB) and
`k8s.io/client-go` (~30 MB) are both unavoidable and account for
nearly all of the difference. UPX would shave it but adds a startup
cost not worth paying on a long-running server. The realistic ceiling
for this app is `< 80 MB`.

**Builder image:** issue body called for `golang:1.22-alpine`, but the
repo is on `go 1.26.0` (`go.mod`) / `1.26.3` (`mise.toml`), so the
Dockerfile uses `golang:1.26-alpine`.

Closes #23

## Test plan

- [x] `make image` builds locally
- [x] `docker run -p 8080:8080 northwatch:dev serve --no-cluster` runs with NO volumes and `curl localhost:8080/healthz` returns 200
- [x] Container runs as UID 65532 (`docker top` + `docker inspect`)
- [x] SQLite opens at `/var/lib/northwatch/northwatch.db` (server log line confirms)
- [x] Default config loaded from `/etc/northwatch/northwatch.yaml` (server log line confirms)
- [x] Image size recorded (70.2 MB; deviates from issue's <30 MB — see Summary)
- [x] PR run of `Build image` workflow completes, including in-CI smoke test with explicit non-root + UID + healthz assertions

### Post-merge follow-up

These can only be verified once the merge commit triggers the
push-to-`main` path of the workflow:

- [x] First push to `main` produces `ghcr.io/northwatchlabs/northwatch:latest` and a cosign signature (signatures live in the OCI 1.1 referrers index, modern cosign default).
- [x] Pulled image manifest reports both `linux/amd64` and `linux/arm64` (verified via `docker buildx imagetools inspect`).