### PR TITLE
Add merge queue support to CI workflows

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -6,6 +6,8 @@ on:
     tags: ['v*']
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read
@@ -15,13 +17,11 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build:
-    name: Build and publish container image
+  verify-image:
+    name: Verify container image
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write   # push to ghcr.io
-      id-token: write   # cosign keyless OIDC
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -81,8 +81,36 @@ jobs:
           docker rm -f nw >/dev/null || true
           exit 1
 
+      - name: Validate multi-arch build
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
+        with:
+          context: .
+          file: deploy/docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  publish-image:
+    name: Build and publish container image
+    if: github.event_name == 'push'
+    needs: verify-image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write   # push to ghcr.io
+      id-token: write   # cosign keyless OIDC
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4.0.0
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
+
       - name: Log in to GHCR
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -108,18 +136,16 @@ jobs:
           context: .
           file: deploy/docker/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Install cosign
-        if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
 
       - name: Sign published image
-        if: github.event_name != 'pull_request'
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
           TAGS: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/verify-pr.yaml
+++ b/.github/workflows/verify-pr.yaml
@@ -3,8 +3,8 @@ name: Verify PR
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Trigger `verify-pr` and `build-image` on `merge_group` so GitHub's merge queue can run them against the speculative merge of `main` + queued PRs.
- Drop `push: branches: [main]` from `verify-pr` — the queue already verifies the exact merged commit, so re-running on push is redundant.
- Split `build-image` into two jobs to honor least-privilege:
  - `verify-image` runs on every event with `contents: read` only. Builds the single-arch image, runs the runtime smoke test (`/healthz`, non-root checks), and validates the multi-arch build so PR/merge-queue runs still catch `linux/arm64` regressions.
  - `publish-image` runs only on `push` events (`main` + `v*` tags), `needs: verify-image`, and holds the `packages: write` + `id-token: write` scopes used by GHCR push and cosign signing. PR and merge-queue events never even instantiate the elevated-perm job.

## Test plan

- [x] Branch protection on `main` has the merge queue enabled and the required checks listed.
- [x] **Required-check list updated**: `Build and publish container image` removed, `Verify container image` added.
- [x] On this PR, all required checks (`Vet, test, lint`, four `Build (cross-platform)` matrix entries, `Run goreleaser snapshot`, `Verify container image`) run and pass against the PR head.
- [x] Clicking **Merge when ready** drops the PR into the merge queue; the queue re-runs the required checks against the speculative merge ref and merges on success.
- [x] After merge, on push to main: `verify-image` runs and passes (smoke test + multi-arch build), then `publish-image` runs (login, build & push, cosign install, sign), and a new `ghcr.io/northwatchlabs/northwatch` image is published and signed.
- [x] `verify-pr` does NOT run on push to main after merge.