### PR TITLE
Add integration test exercising the killer demo

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,83 @@
+name: Run killer-demo e2e
+
+on:
+  pull_request:
+    branches: [main]
+  merge_group:
+    types: [checks_requested]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: Run killer-demo e2e
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        timeout-minutes: 2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        with:
+          go-version-file: go.mod
+        timeout-minutes: 3
+
+      - name: Set up Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
+        with:
+          version: 4.2.0
+        timeout-minutes: 1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4.0.0
+        timeout-minutes: 1
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
+        timeout-minutes: 1
+
+      - name: Resolve chart appVersion
+        id: appver
+        run: |
+          set -euo pipefail
+          v=$(helm show chart deploy/helm/northwatch \
+            | awk '/^appVersion:/ {gsub(/"/, "", $2); print $2; exit}')
+          echo "value=$v" >> "$GITHUB_OUTPUT"
+
+      - name: Build NorthWatch image
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
+        with:
+          context: .
+          file: deploy/docker/Dockerfile
+          platforms: linux/amd64
+          load: true
+          tags: ghcr.io/northwatchlabs/northwatch:${{ steps.appver.outputs.value }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+        timeout-minutes: 5
+
+      - name: Create kind cluster
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc  # v1.14.0
+        with:
+          cluster_name: northwatch-e2e
+          wait: 60s
+        timeout-minutes: 3
+
+      - name: Load image into kind
+        run: |
+          kind load docker-image \
+            "ghcr.io/northwatchlabs/northwatch:${{ steps.appver.outputs.value }}" \
+            --name northwatch-e2e
+        timeout-minutes: 2
+
+      - name: Run killer-demo e2e
+        env:
+          E2E_CLUSTER: northwatch-e2e
+        run: |
+          go test -tags=e2e -count=1 -timeout 10m -v ./test/e2e/...
+        timeout-minutes: 12

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BIN := northwatch
 PKG := ./...
 IMAGE ?= northwatch:dev
 
-.PHONY: help build run test vet lint css image clean helm-lint helm-smoke helm-smoke-v3
+.PHONY: help build run test vet lint css image clean helm-lint helm-smoke helm-smoke-v3 e2e
 
 help: ## Show this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make <target>\n\nTargets:\n"} /^[a-zA-Z0-9_-]+:.*##/ { printf "  %-14s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
@@ -61,3 +61,24 @@ helm-smoke-v3: ## Run the chart smoke test against Helm 3.21.0 (downloaded into 
 	helm3="$$tmp/$${os}-$${arch}/helm"; \
 	"$$helm3" version --short; \
 	HELM="$$helm3" KIND_CLUSTER=northwatch-smoke-v3 bash deploy/helm/scripts/smoke.sh
+
+e2e: ## Run the killer-demo e2e: kind up, build/load image, run go test, kind down.
+	@set -eu; \
+	cluster="northwatch-e2e"; \
+	cleanup() { \
+	  [ -n "$${E2E_KEEP_CLUSTER:-}" ] && return 0; \
+	  kind delete cluster --name "$$cluster" >/dev/null 2>&1 || true; \
+	}; \
+	trap cleanup EXIT; \
+	trap 'trap - EXIT INT TERM; cleanup; exit 130' INT; \
+	trap 'trap - EXIT INT TERM; cleanup; exit 143' TERM; \
+	app_version=$$(helm show chart deploy/helm/northwatch \
+	  | awk '/^appVersion:/ {gsub(/"/, "", $$2); print $$2; exit}'); \
+	image="ghcr.io/northwatchlabs/northwatch:$$app_version"; \
+	echo "==> appVersion=$$app_version image=$$image cluster=$$cluster"; \
+	if ! kind get clusters | grep -qx "$$cluster"; then \
+	  kind create cluster --name "$$cluster" --wait 60s; \
+	fi; \
+	docker build -f deploy/docker/Dockerfile -t "$$image" .; \
+	kind load docker-image "$$image" --name "$$cluster"; \
+	E2E_CLUSTER="$$cluster" $(GO) test -tags=e2e -count=1 -timeout 10m -v ./test/e2e/...

--- a/deploy/helm/ci/e2e-values.yaml
+++ b/deploy/helm/ci/e2e-values.yaml
@@ -1,0 +1,10 @@
+# Fixture used by test/e2e and the e2e.yaml workflow. Points the
+# watcher at the dedicated e2e workload so this test stays
+# isolated from deploy/helm/ci/smoke-values.yaml (which targets
+# default/api-gateway and is used by the helm smoke).
+config: |
+  components:
+    - kind: Deployment
+      namespace: northwatch-e2e-workload
+      name: api-gateway
+      displayName: "API Gateway (e2e)"

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -1,0 +1,429 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+var jsonUnmarshal = json.Unmarshal
+
+// env holds resolved e2e runtime configuration.
+type env struct {
+	cluster string // kind cluster name (E2E_CLUSTER, default northwatch-e2e)
+	context string // kubectl context name (kind-<cluster>)
+	port    string // host port for kubectl port-forward (E2E_PORT, default 18081)
+	apiBase string // base URL for HTTP calls (http://127.0.0.1:<port>)
+	token   string // bearer token; must be >=16 chars to match server validation
+}
+
+const (
+	releaseName       = "nw"
+	releaseNamespace  = "northwatch"
+	workloadNamespace = "northwatch-e2e-workload"
+	componentID       = "Deployment/northwatch-e2e-workload/api-gateway"
+	bearerToken       = "e2e-test-token-00" // 17 chars; server enforces >=16
+	incidentTitle     = "e2e: scaled to zero"
+)
+
+func envFromOS() env {
+	cluster := os.Getenv("E2E_CLUSTER")
+	if cluster == "" {
+		cluster = "northwatch-e2e"
+	}
+	port := os.Getenv("E2E_PORT")
+	if port == "" {
+		port = "18081"
+	}
+	return env{
+		cluster: cluster,
+		context: "kind-" + cluster,
+		port:    port,
+		apiBase: "http://127.0.0.1:" + port,
+		token:   bearerToken,
+	}
+}
+
+// requireContext fails the test if the configured kube context does
+// not exist. Without this, bare kubectl/helm calls would target
+// whatever the developer's current context happens to be.
+func requireContext(t *testing.T, e env) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "kubectl", "config", "get-contexts", "-o", "name").CombinedOutput()
+	if err != nil {
+		t.Fatalf("kubectl config get-contexts failed: %v\n%s", err, out)
+	}
+	for _, name := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if name == e.context {
+			return
+		}
+	}
+	t.Fatalf("kube context %q not found; available contexts:\n%s", e.context, out)
+}
+
+// runCmd runs an external command with a per-call timeout. Returns
+// combined stdout+stderr on both success and failure so callers can
+// log it in diagnostics.
+func runCmd(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	return cmd.CombinedOutput()
+}
+
+// kubectl runs `kubectl --context <ctx> <args>` with a 30s default
+// timeout. Use longer-timeout variants for `wait` / `scale` etc.
+func kubectl(t *testing.T, e env, args ...string) ([]byte, error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	full := append([]string{"--context", e.context}, args...)
+	return runCmd(ctx, "kubectl", full...)
+}
+
+// kubectlT lets the caller set a custom timeout (used for `wait`).
+func kubectlT(t *testing.T, e env, timeout time.Duration, args ...string) ([]byte, error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	full := append([]string{"--context", e.context}, args...)
+	return runCmd(ctx, "kubectl", full...)
+}
+
+// helm runs `helm <subcommand> --kube-context <ctx> <args>` with a
+// caller-supplied timeout. Helm gets its own helper because the
+// outer context must exceed Helm's internal --timeout by ~30s so
+// Helm's error surfaces cleanly instead of being preempted.
+func helm(t *testing.T, e env, timeout time.Duration, args ...string) ([]byte, error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	full := append([]string{args[0], "--kube-context", e.context}, args[1:]...)
+	return runCmd(ctx, "helm", full...)
+}
+
+// httpGet performs GET with a 10s timeout. Body is returned as a
+// string so substring assertions are easy.
+func httpGet(t *testing.T, url string) (int, string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest %s: %v", url, err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("GET %s: read body: %v", url, err)
+	}
+	return resp.StatusCode, string(body)
+}
+
+// httpPostJSON performs POST application/json with bearer auth and
+// a 10s timeout.
+func httpPostJSON(t *testing.T, url, token, body string) (int, string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("http.NewRequest %s: %v", url, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	out, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("POST %s: read body: %v", url, err)
+	}
+	return resp.StatusCode, string(out)
+}
+
+// run is a thin convenience: fail the test with command output on
+// non-zero exit.
+func run(t *testing.T, label string, out []byte, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("%s failed: %v\n%s", label, err, bytes.TrimSpace(out))
+	}
+}
+
+// pollUntil calls fn every interval until it returns nil or the
+// deadline elapses. On timeout it dumps diagnostics synchronously
+// via diag.fatal so cluster state is captured before any cleanup
+// runs. Without the diag route, the safety-net t.Cleanup would fire
+// last in LIFO order — after resource teardowns — and the dump
+// would describe a torn-down cluster.
+func pollUntil(t *testing.T, diag *diagBundle, label string, deadline, interval time.Duration, fn func() error) {
+	t.Helper()
+	end := time.Now().Add(deadline)
+	var lastErr error
+	for {
+		lastErr = fn()
+		if lastErr == nil {
+			return
+		}
+		if time.Now().After(end) {
+			diag.fatal(t, "%s: timed out after %s; last error: %v", label, deadline, lastErr)
+		}
+		time.Sleep(interval)
+	}
+}
+
+// diagBundle captures the bits we want to dump on failure. The
+// HTTP bodies are the most recent values observed by the polling
+// helpers, so callers can update them as the test progresses.
+type diagBundle struct {
+	env            env
+	lastComponents string
+	lastIncidents  string
+}
+
+// newDiag returns a bundle and registers the diagnostic dump as a
+// t.Cleanup. The dump checks t.Failed() and is a no-op on success.
+// Registering this BEFORE any other t.Cleanup means it runs LAST
+// in LIFO order — i.e., after resource cleanups remove the cluster
+// state. We accept that for the safety-net role; the primary path
+// is callers explicitly invoking diag.Dump(t) before t.Fatal via
+// the fatal helper below.
+func newDiag(t *testing.T, e env) *diagBundle {
+	t.Helper()
+	d := &diagBundle{env: e}
+	t.Cleanup(func() {
+		if t.Failed() {
+			d.Dump(t)
+		}
+	})
+	return d
+}
+
+// Dump emits the diagnostic bundle via t.Logf. Safe to call
+// multiple times; individual command failures are tolerated.
+func (d *diagBundle) Dump(t *testing.T) {
+	t.Helper()
+	e := d.env
+
+	dump := func(label string, out []byte, err error) {
+		if err != nil {
+			t.Logf("[diag] %s: error: %v\n%s", label, err, out)
+			return
+		}
+		t.Logf("[diag] %s:\n%s", label, out)
+	}
+
+	out, err := helm(t, e, 15*time.Second, "status", releaseName, "--namespace", releaseNamespace)
+	dump("helm status", out, err)
+
+	out, err = kubectl(t, e, "-n", releaseNamespace, "get", "pods,deploy,svc,events", "--sort-by=.lastTimestamp")
+	dump("kubectl get -n "+releaseNamespace, out, err)
+
+	out, err = kubectl(t, e, "-n", releaseNamespace, "describe", "pods,deploy")
+	dump("kubectl describe -n "+releaseNamespace, out, err)
+
+	out, err = kubectl(t, e, "-n", releaseNamespace, "logs", "deploy/"+releaseName+"-northwatch", "--tail=200")
+	dump("kubectl logs", out, err)
+
+	out, err = kubectl(t, e, "-n", releaseNamespace, "logs", "deploy/"+releaseName+"-northwatch", "--previous", "--tail=200")
+	dump("kubectl logs --previous", out, err)
+
+	out, err = kubectl(t, e, "-n", workloadNamespace, "describe", "deploy/api-gateway")
+	dump("kubectl describe -n "+workloadNamespace+" deploy/api-gateway", out, err)
+
+	if d.lastComponents != "" {
+		t.Logf("[diag] last /api/components: %s", d.lastComponents)
+	}
+	if d.lastIncidents != "" {
+		t.Logf("[diag] last /api/incidents: %s", d.lastIncidents)
+	}
+}
+
+// fatal dumps the bundle synchronously and then calls t.Fatalf.
+// Use this instead of t.Fatal for any failure that happens while
+// cluster state is still useful to inspect.
+func (d *diagBundle) fatal(t *testing.T, format string, args ...any) {
+	t.Helper()
+	d.Dump(t)
+	t.Fatalf(format, args...)
+}
+
+// preInstallReset wipes any stale NorthWatch release / namespace /
+// cluster-scoped RBAC. Safe to call against a clean cluster (each
+// step is independently no-op-on-missing).
+func preInstallReset(t *testing.T, e env) {
+	t.Helper()
+
+	// helm uninstall (only if installed)
+	if _, statusErr := helm(t, e, 15*time.Second, "status", releaseName, "--namespace", releaseNamespace); statusErr == nil {
+		out, err := helm(t, e, 90*time.Second,
+			"uninstall", releaseName,
+			"--namespace", releaseNamespace,
+			"--wait", "--timeout", "60s")
+		if err != nil {
+			t.Logf("preInstallReset: helm uninstall: %v\n%s", err, out)
+		}
+	}
+
+	// delete cluster-scoped RBAC the chart owns
+	if out, err := kubectl(t, e, "delete", "clusterrole,clusterrolebinding",
+		"-l", "app.kubernetes.io/instance="+releaseName, "--ignore-not-found"); err != nil {
+		t.Logf("preInstallReset: delete RBAC: %v\n%s", err, out)
+	}
+
+	// delete the namespace, waiting for it to finish so the next
+	// install --create-namespace doesn't race with a Terminating
+	// state.
+	if out, err := kubectlT(t, e, 90*time.Second, "delete", "namespace", releaseNamespace,
+		"--ignore-not-found", "--wait"); err != nil {
+		t.Logf("preInstallReset: delete namespace: %v\n%s", err, out)
+	}
+}
+
+// teardownNorthwatch is the same logic registered as t.Cleanup
+// after install. Uses --wait=false on the namespace delete because
+// the next test run's preInstallReset will wait for it.
+func teardownNorthwatch(t *testing.T, e env) {
+	t.Helper()
+	if out, err := helm(t, e, 90*time.Second,
+		"uninstall", releaseName,
+		"--namespace", releaseNamespace,
+		"--wait", "--timeout", "60s"); err != nil {
+		t.Logf("teardown: helm uninstall: %v\n%s", err, out)
+	}
+	if out, err := kubectl(t, e, "delete", "clusterrole,clusterrolebinding",
+		"-l", "app.kubernetes.io/instance="+releaseName, "--ignore-not-found"); err != nil {
+		t.Logf("teardown: delete RBAC: %v\n%s", err, out)
+	}
+	if out, err := kubectl(t, e, "delete", "namespace", releaseNamespace,
+		"--ignore-not-found", "--wait=false"); err != nil {
+		t.Logf("teardown: delete namespace: %v\n%s", err, out)
+	}
+}
+
+// portForward starts kubectl port-forward in the background and
+// returns a stop function (registered as t.Cleanup by the caller).
+// It blocks until either the port responds to GET /healthz or the
+// timeout elapses.
+func portForward(t *testing.T, e env) func() {
+	t.Helper()
+
+	args := []string{
+		"--context", e.context,
+		"-n", releaseNamespace,
+		"port-forward",
+		"svc/" + releaseName + "-northwatch",
+		e.port + ":8080",
+	}
+	cmd := exec.Command("kubectl", args...)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("port-forward stdout pipe: %v", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		t.Fatalf("port-forward stderr pipe: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("port-forward start: %v", err)
+	}
+
+	// Drain stdout/stderr so the buffers don't block kubectl.
+	go func() { _, _ = io.Copy(io.Discard, stdout) }()
+	go func() { _, _ = io.Copy(io.Discard, stderr) }()
+
+	stop := func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	}
+
+	// Wait until /healthz responds (max 15s).
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		if code, _ := tryGet(t, e.apiBase+"/healthz"); code == http.StatusOK {
+			return stop
+		}
+		if time.Now().After(deadline) {
+			stop()
+			t.Fatalf("port-forward: /healthz never returned 200 within 15s")
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+// tryGet is like httpGet but returns (0, "") on transport errors
+// instead of failing the test. Used by readiness loops.
+func tryGet(t *testing.T, url string) (int, string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, ""
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, ""
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(body)
+}
+
+// apiComponent matches the wire shape returned by GET
+// /api/components. Only the fields the e2e cares about.
+type apiComponent struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Status string `json:"status"`
+}
+
+// fetchComponents records the raw body on diag and returns parsed
+// components. Returns an error (rather than calling t.Fatal) so it
+// can be used inside polling loops — uses tryGet so transient port-
+// forward blips are returned as retryable errors instead of aborting
+// the whole test.
+func fetchComponents(t *testing.T, e env, diag *diagBundle) ([]apiComponent, error) {
+	t.Helper()
+	code, body := tryGet(t, e.apiBase+"/api/components")
+	diag.lastComponents = body
+	if code == 0 {
+		return nil, fmt.Errorf("GET /api/components: transport error")
+	}
+	if code != 200 {
+		return nil, fmt.Errorf("GET /api/components: status %d body=%s", code, body)
+	}
+	var comps []apiComponent
+	if err := jsonUnmarshal([]byte(body), &comps); err != nil {
+		return nil, fmt.Errorf("decode /api/components: %v body=%s", err, body)
+	}
+	return comps, nil
+}
+
+// findAPIGateway returns the api-gateway component or an error if
+// missing.
+func findAPIGateway(comps []apiComponent) (apiComponent, error) {
+	for _, c := range comps {
+		if c.Name == "api-gateway" {
+			return c, nil
+		}
+	}
+	return apiComponent{}, fmt.Errorf("api-gateway component not present in /api/components")
+}

--- a/test/e2e/killer_demo_test.go
+++ b/test/e2e/killer_demo_test.go
@@ -1,0 +1,174 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestKillerDemo(t *testing.T) {
+	e := envFromOS()
+	requireContext(t, e)
+	diag := newDiag(t, e)
+
+	// Step 1: Apply sample workload, wait Available.
+	workloadManifest := "testdata/sample-deployment.yaml"
+	if out, err := kubectl(t, e, "apply", "-f", workloadManifest); err != nil {
+		diag.fatal(t, "apply sample workload: %v\n%s", err, out)
+	}
+	t.Cleanup(func() {
+		if out, err := kubectl(t, e, "delete", "-f", workloadManifest, "--ignore-not-found"); err != nil {
+			t.Logf("cleanup: delete sample workload: %v\n%s", err, out)
+		}
+	})
+	if out, err := kubectlT(t, e, 90*time.Second, "-n", workloadNamespace,
+		"wait", "deploy/api-gateway", "--for=condition=available", "--timeout=60s"); err != nil {
+		diag.fatal(t, "wait sample workload Available: %v\n%s", err, out)
+	}
+
+	// Step 2: Pre-install reset, then install NorthWatch.
+	preInstallReset(t, e)
+	t.Cleanup(func() { teardownNorthwatch(t, e) })
+
+	chartPath := "../../deploy/helm/northwatch"
+	valuesPath := "../../deploy/helm/ci/e2e-values.yaml"
+	if out, err := helm(t, e, 150*time.Second,
+		"install", releaseName, chartPath,
+		"--namespace", releaseNamespace, "--create-namespace",
+		"--set", "auth.token="+e.token,
+		"--values", valuesPath,
+		"--wait", "--timeout", "120s"); err != nil {
+		diag.fatal(t, "helm install: %v\n%s", err, out)
+	}
+
+	// Step 3: Port-forward.
+	stopPF := portForward(t, e)
+	t.Cleanup(stopPF)
+
+	// Smoke check.
+	if code, body := httpGet(t, e.apiBase+"/healthz"); code != 200 {
+		diag.fatal(t, "/healthz returned %d: %s", code, body)
+	}
+
+	// Step 4: Wait operational, capture component ID.
+	var apiGW apiComponent
+	pollUntil(t, diag, "api-gateway operational", 30*time.Second, 1*time.Second, func() error {
+		comps, err := fetchComponents(t, e, diag)
+		if err != nil {
+			return err
+		}
+		c, err := findAPIGateway(comps)
+		if err != nil {
+			return err
+		}
+		if c.Status != "operational" {
+			return fmt.Errorf("status=%q want operational", c.Status)
+		}
+		apiGW = c
+		return nil
+	})
+	if apiGW.ID != componentID {
+		diag.fatal(t, "component ID = %q, want %q", apiGW.ID, componentID)
+	}
+
+	// Step 5: Scale to zero, wait for down (120s past debounce).
+	if out, err := kubectl(t, e, "-n", workloadNamespace,
+		"scale", "deploy/api-gateway", "--replicas=0"); err != nil {
+		diag.fatal(t, "scale to 0: %v\n%s", err, out)
+	}
+	pollUntil(t, diag, "api-gateway down", 120*time.Second, 1*time.Second, func() error {
+		comps, err := fetchComponents(t, e, diag)
+		if err != nil {
+			return err
+		}
+		c, err := findAPIGateway(comps)
+		if err != nil {
+			return err
+		}
+		if c.Status != "down" {
+			return fmt.Errorf("status=%q want down", c.Status)
+		}
+		return nil
+	})
+
+	// Step 6: Create incident, capture id.
+	body := fmt.Sprintf(`{"component":%q,"title":%q}`, componentID, incidentTitle)
+	code, respBody := httpPostJSON(t, e.apiBase+"/incidents", e.token, body)
+	if code != 201 {
+		diag.fatal(t, "POST /incidents: status %d body=%s", code, respBody)
+	}
+	var created struct {
+		ID string `json:"id"`
+	}
+	if err := jsonUnmarshal([]byte(respBody), &created); err != nil {
+		diag.fatal(t, "decode POST /incidents response: %v body=%s", err, respBody)
+	}
+	if created.ID == "" {
+		diag.fatal(t, "POST /incidents: empty id in body=%s", respBody)
+	}
+
+	// Step 7: Assert incident banner present.
+	code, page := httpGet(t, e.apiBase+"/")
+	if code != 200 {
+		diag.fatal(t, "GET / : status %d", code)
+	}
+	if !strings.Contains(page, incidentTitle) {
+		diag.fatal(t, "GET /: body missing incident title %q\nbody:\n%s", incidentTitle, page)
+	}
+	if !strings.Contains(page, "text-red-900") {
+		diag.fatal(t, "GET /: body missing red-banner class text-red-900\nbody:\n%s", page)
+	}
+
+	// Step 8: Resolve incident.
+	code, respBody = httpPostJSON(t, e.apiBase+"/incidents/"+created.ID+"/resolve", e.token, "")
+	if code != 200 {
+		diag.fatal(t, "POST resolve: status %d body=%s", code, respBody)
+	}
+
+	// Step 9: Restore replicas, wait operational again.
+	if out, err := kubectl(t, e, "-n", workloadNamespace,
+		"scale", "deploy/api-gateway", "--replicas=3"); err != nil {
+		diag.fatal(t, "scale to 3: %v\n%s", err, out)
+	}
+	pollUntil(t, diag, "api-gateway operational (recovery)", 60*time.Second, 1*time.Second, func() error {
+		comps, err := fetchComponents(t, e, diag)
+		if err != nil {
+			return err
+		}
+		c, err := findAPIGateway(comps)
+		if err != nil {
+			return err
+		}
+		if c.Status != "operational" {
+			return fmt.Errorf("status=%q want operational", c.Status)
+		}
+		return nil
+	})
+
+	// Step 10: Assert banner cleared.
+	code, page = httpGet(t, e.apiBase+"/")
+	if code != 200 {
+		diag.fatal(t, "GET / (final): status %d", code)
+	}
+	if !strings.Contains(page, "All Systems Operational") {
+		diag.fatal(t, "GET /: missing 'All Systems Operational'\nbody:\n%s", page)
+	}
+	for _, banned := range []string{incidentTitle, "text-red-900", "Some Systems Degraded"} {
+		if strings.Contains(page, banned) {
+			diag.fatal(t, "GET /: should not contain %q after resolve+recovery\nbody:\n%s", banned, page)
+		}
+	}
+
+	// Assert the incident is no longer active.
+	code, incBody := httpGet(t, e.apiBase+"/api/incidents")
+	diag.lastIncidents = incBody
+	if code != 200 {
+		diag.fatal(t, "GET /api/incidents: status %d", code)
+	}
+	if strings.Contains(incBody, created.ID) {
+		diag.fatal(t, "GET /api/incidents: resolved id %q still active\nbody:\n%s", created.ID, incBody)
+	}
+}

--- a/test/e2e/testdata/sample-deployment.yaml
+++ b/test/e2e/testdata/sample-deployment.yaml
@@ -1,0 +1,40 @@
+# Sample workload for the killer-demo e2e test.
+#
+# Pairs with deploy/helm/ci/e2e-values.yaml: the watched component
+# Deployment/northwatch-e2e-workload/api-gateway matches this
+# Deployment. Lives in a dedicated namespace so the e2e never
+# touches a user's default/api-gateway on a kept kind cluster.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: northwatch-e2e-workload
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-gateway
+  namespace: northwatch-e2e-workload
+  labels:
+    app: api-gateway
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: api-gateway
+  template:
+    metadata:
+      labels:
+        app: api-gateway
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.27-alpine
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi


### PR DESCRIPTION
## Summary

- Add Go integration test (`test/e2e/killer_demo_test.go`, build-tagged `e2e`) that drives the full page-22 killer demo against a kind cluster: apply sample workload, helm-install NorthWatch, wait operational, scale to 0 and wait through the 60s downward debounce, POST an incident and assert the red banner, resolve, scale back to 3 and wait for recovery, then assert "All Systems Operational" with negative checks against stale incident markup.
- Add `make e2e` target with a signal-safe trap that creates the kind cluster, builds + loads the NorthWatch image, runs the test, and tears down (covers `EXIT`, `SIGINT`, `SIGTERM`).
- Add `.github/workflows/e2e.yaml` as the v0.1.0 release gate: runs on PR + merge_group + push-to-main (no path filter), pinned 40-char action SHAs matching `verify-helm-chart.yaml`, per-step `timeout-minutes` plus a 20-min job ceiling.
- Use a dedicated workload namespace (`northwatch-e2e-workload`) and an e2e-only Helm values file (`deploy/helm/ci/e2e-values.yaml`) so the test never touches a user's `default/api-gateway` on a kept kind cluster.

Closes #25

## Test plan

- [x] `make e2e` runs locally and passes (`--- PASS: TestKillerDemo (80.95s)` against kind 0.31.0 / helm 4.2.0)
- [x] `make test` (no `-tags=e2e`) still green and skips the e2e package
- [x] `go test ./test/e2e/...` (no tag) reports no buildable Go files — e2e is invisible without the tag
- [x] `e2e.yaml` workflow runs green on this PR
- [x] `verify-helm-chart.yaml` (existing smoke) stays green on this PR