### PR TITLE
Add question issue template and breaking-changes section to PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,17 @@
+---
+name: Question
+about: Ask a question about how NorthWatch works or how to use it.
+title: ""
+type: question
+assignees: "demisx"
+labels: ""
+---
+
+## Question
+
+...
+
+## Context
+
+<!-- What are you trying to do? What have you tried? Relevant version,
+config, or environment details. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,14 @@ Closes # or Part of #
 <!-- How this was / will be verified. Include pre-merge and post-merge checks (e.g. smoke test in target env, dashboard check) when applicable. -->
 - [ ]
 
+## Breaking changes
+<!-- Tick the box if this PR introduces any breaking change. If yes,
+describe the break and any migration steps. Examples: removed or
+renamed public API or CLI flag, changed default behavior, changed
+config or HelmRelease values shape, dropped support for an OS or
+version. -->
+- [ ] This PR introduces a breaking change
+
 ## PR Checklist
 - [ ] Branch rebased on latest `origin/main` with commits squashed
 - [ ] Issue, if exists, is linked


### PR DESCRIPTION
## Summary

- Add `.github/ISSUE_TEMPLATE/question.md` so contributors have a dedicated path for questions without enabling GitHub Discussions yet.
- Add a **Breaking changes** section + checkbox to `.github/pull_request_template.md` so reviewers and downstream users get an unambiguous signal when a PR breaks compatibility.
- Other templates from #2's task list (bug, feature, config.yml with blank-issues disabled) already existed and stay as-is.

Closes #2

## Test plan

- [x] `.github/ISSUE_TEMPLATE/question.md` renders correctly in GitHub's "New issue" picker (frontmatter follows the same shape as the existing templates).
- [x] PR template diff is two additions: a heading + checkbox under Test plan.
- [ ] CI green on this PR.