### PR TITLE
Reject short auth.token in Helm values schema

### DIFF
--- a/deploy/helm/northwatch/README.md
+++ b/deploy/helm/northwatch/README.md
@@ -34,7 +34,7 @@ This chart targets the **Helm 3 + Helm 4 common feature set**. CI runs
 | `rbac.create` | `true` | ClusterRole grants `get,list,watch` on Deployments, HelmReleases, Kustomizations, Applications. |
 | `auth.existingSecret` | `""` | If set, references a pre-existing Secret holding the API token. |
 | `auth.existingSecretKey` | `token` | Key inside `existingSecret`. |
-| `auth.token` | `""` | Literal token written into a chart-managed Secret. |
+| `auth.token` | `""` | Literal token written into a chart-managed Secret. Must be empty or at least 16 characters — shorter values fail schema validation. |
 | `service.port` | `8080` | ClusterIP only; wire your own Ingress. |
 | `resources.requests` | `50m` CPU / `64Mi` mem | Override per environment. |
 | `resources.limits` | `500m` CPU / `256Mi` mem | |

--- a/deploy/helm/northwatch/values.schema.json
+++ b/deploy/helm/northwatch/values.schema.json
@@ -33,7 +33,14 @@
       "properties": {
         "existingSecret":    { "type": "string" },
         "existingSecretKey": { "type": "string" },
-        "token":             { "type": "string" }
+        "token": {
+          "type": "string",
+          "anyOf": [
+            { "maxLength": 0 },
+            { "minLength": 16 }
+          ],
+          "description": "Literal API token. Must be empty (chart auto-generates) or at least 16 characters — the binary refuses to start with a shorter token."
+        }
       }
     },
     "service": {


### PR DESCRIPTION
## Summary

The Helm chart's `values.schema.json` accepted any string for
`auth.token`, including values shorter than 16 chars. The binary
refuses to start with a token under 16 chars, so `helm install
--set auth.token=hunter2` validated and installed cleanly, then
the pod CrashLoopBackoffed with an obscure log line.

This tightens the schema so a short literal token fails `helm
install` with a clear validation error. Empty string remains valid
— the chart auto-generates a 32-char token in that path.

## Linked issue

Closes #69

## Test plan

- [x] `helm lint deploy/helm/northwatch` passes with default values
- [x] `helm lint deploy/helm/northwatch --set auth.token=hunter2` fails with `'anyOf' failed` schema error
- [x] `helm lint deploy/helm/northwatch --set auth.token=abcdefghijklmnop` passes (16 chars)
- [x] `helm lint deploy/helm/northwatch --set auth.token=""` passes (empty → chart auto-generates)
- [x] E2E test's hardcoded `e2e-test-token-00` (17 chars) still satisfies the schema

## Breaking changes

- [ ] This PR introduces a breaking change

## PR Checklist

- [ ] Branch rebased on latest `origin/main` with commits squashed
- [x] Issue, if exists, is linked
- [x] Pre-merge Test plan items checked off
- [ ] All reviewer comments resolved