### PR TITLE
Refresh README for v0.1.0 ship

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,33 +4,84 @@ Open-source, GitOps-native, Kubernetes-aware status page with first-class
 incident management. Single Go binary, single config file, Apache 2.0.
 
 NorthWatch derives component health directly from Kubernetes resources
-(`status.conditions`, replica readiness) on `Deployment`, `HelmRelease`
-(Flux), and `Application` (ArgoCD) — no manual ping configuration. Run
-it as a container or install via Helm.
+(`status.conditions`, replica readiness) on `Deployment`, Flux
+`HelmRelease`, Flux `Kustomization`, and ArgoCD `Application` — no
+manual ping configuration. Run it as a container, install via Helm, or
+run the binary directly against a kubeconfig.
 
-> Status: pre-v0.1.0. The MVP is under active development. APIs,
-> configuration, and Helm chart values may change without notice until
-> v0.1.0 ships.
+> **v0.1.0 — MVP is live.** Container image:
+> [`ghcr.io/northwatchlabs/northwatch:0.1.0`](https://github.com/northwatchlabs/northwatch/pkgs/container/northwatch).
+> Binaries + checksums on the
+> [v0.1.0 Release](https://github.com/northwatchlabs/northwatch/releases/tag/v0.1.0).
 
-## Try it locally
+## Quickstart — Helm
 
-Walks the current functionality end-to-end against a real Kubernetes
-cluster. Prerequisites: [mise](https://mise.jdx.dev/) (drives every
-other tool — see [Develop](#develop)) and a running Docker daemon
-(for `kind`).
+The fastest path to the killer demo. Prerequisites:
+[mise](https://mise.jdx.dev/) (drives every tool — see [Develop](#develop))
+and Docker (for `kind`).
 
-### 1. Build the binary
+```sh
+# 1. Bring up a local cluster + the workload to watch.
+mise trust && mise install
+kind create cluster --name nw-demo
+kubectl --context kind-nw-demo apply -f examples/basic/sample-deployment.yaml
+
+# 2. Install NorthWatch from the in-tree chart. Pin the published image
+#    tag so you're running v0.1.0 exactly.
+kubectl --context kind-nw-demo create namespace northwatch
+helm --kube-context kind-nw-demo install nw deploy/helm/northwatch \
+    --namespace northwatch \
+    --set image.tag=0.1.0 \
+    --set-file config=examples/basic/northwatch.yaml
+
+# 3. Port-forward, then visit the status page in your browser.
+kubectl --context kind-nw-demo -n northwatch port-forward svc/nw-northwatch 8080:8080 &
+# http://localhost:8080
+```
+
+**API Gateway** shows as `operational`. Scale the workload to zero and
+refresh; it flips to `down` within ~1s. Scale back; it returns to
+`operational` once the rollout completes.
+
+### Killer demo: incident banner
+
+The chart auto-generates a bearer token. Retrieve it, then open and
+resolve an incident:
+
+```sh
+TOKEN=$(kubectl --context kind-nw-demo -n northwatch get secret \
+    nw-northwatch-api-token -o jsonpath='{.data.token}' | base64 --decode)
+
+# Open an incident — a red banner appears on the status page.
+RESPONSE=$(curl -fsS -X POST http://localhost:8080/incidents \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{"title":"Investigating elevated 5xx errors","component":"Deployment/default/api-gateway"}')
+ID=$(printf '%s' "$RESPONSE" | sed -n 's/.*"id":"\([^"]*\)".*/\1/p')
+
+# Resolve it — the banner clears.
+curl -fsS -X POST "http://localhost:8080/incidents/$ID/resolve" \
+    -H "Authorization: Bearer $TOKEN"
+```
+
+### Cleanup
+
+```sh
+kind delete cluster --name nw-demo
+```
+
+## Quickstart — binary
+
+For development, smoke testing, or environments where containers aren't
+the right tool. Run the binary against any reachable cluster.
 
 ```sh
 mise trust && mise install
 make build
-```
 
-### 2. Watch a Deployment
-
-```sh
 kind create cluster --name nw-demo
 kubectl --context kind-nw-demo apply -f examples/basic/sample-deployment.yaml
+
 ./northwatch serve \
     --config examples/basic/northwatch.yaml \
     --db /tmp/nw-demo.db \
@@ -39,27 +90,21 @@ kubectl --context kind-nw-demo apply -f examples/basic/sample-deployment.yaml
     --allow-deactivate
 ```
 
-Open <http://localhost:8080>. **API Gateway** shows as `operational`.
-In another terminal, scale the workload and refresh:
-
-```sh
-kubectl --context kind-nw-demo -n default scale deploy/api-gateway --replicas=0
-# status flips to "down" within ~1s
-
-kubectl --context kind-nw-demo -n default scale deploy/api-gateway --replicas=3
-# status returns to "operational" once the rollout completes
-```
+Open <http://localhost:8080>. **API Gateway** shows as `operational`;
+scaling the deployment exercises the status transitions described
+above. The incident API requires `NORTHWATCH_API_TOKEN` to be set —
+export a 16+ char value before launching `northwatch serve` to enable
+write endpoints.
 
 The component config (`examples/basic/northwatch.yaml`) also lists
-`HelmRelease/flux-system/cert-manager`, an ArgoCD `Application`, and
-a Flux `Kustomization`, which will show as `unknown` until those
+`HelmRelease/flux-system/cert-manager`, an ArgoCD `Application`, and a
+Flux `Kustomization`, which will show as `unknown` until those
 controllers are installed. The CRD probes log
 `"Flux HelmRelease CRDs not present, skipping helmrelease watcher"`
-(and the parallel `"ArgoCD CRDs not present, skipping application
-watcher"` / `"Flux Kustomize CRDs not present, skipping kustomization
-watcher"`) and continue — that's expected.
+(and equivalent for ArgoCD / Kustomize) and continue — that's
+expected.
 
-### 3. (Optional) Watch a HelmRelease
+### (Optional) Watch a HelmRelease
 
 To exercise the HelmRelease watcher, install Flux's source and helm
 controllers and apply a real release:
@@ -100,7 +145,7 @@ kubectl --context kind-nw-demo -n default patch hr podinfo \
     --type merge -p '{"spec":{"chart":{"spec":{"version":"999.0.0"}}}}'
 ```
 
-### 4. (Optional) Watch a Flux Kustomization
+### (Optional) Watch a Flux Kustomization
 
 To exercise the Kustomization watcher, install Flux's source and
 kustomize controllers and apply a real Kustomization. The recipe
@@ -142,24 +187,27 @@ kubectl --context kind-nw-demo -n default patch ks podinfo \
     --type merge -p '{"spec":{"path":"./does-not-exist"}}'
 ```
 
-### Cleanup
+## What's shipped in v0.1.0
 
-```sh
-kind delete cluster --name nw-demo
-```
+- Watchers for Kubernetes `Deployment`, Flux `HelmRelease` (v2,
+  v2beta1, v2beta2), Flux `Kustomization`, and ArgoCD `Application`.
+- Status mapping with kstatus-aware freshness and a 60s debounce so
+  rolling updates don't flicker the page.
+- Read-only public status page — server-rendered HTML + HTMX +
+  Tailwind, embedded in the binary.
+- Incident API — `POST /incidents`, `POST /incidents/{id}/resolve` —
+  gated by a single bearer token (`NORTHWATCH_API_TOKEN` /
+  `auth.token` in the chart).
+- SQLite store with migrations.
+- Multi-arch container image (linux/amd64 + arm64), distroless,
+  non-root, cosign-signed.
+- Helm chart at `deploy/helm/northwatch` — installs in <30s. See
+  [`deploy/helm/northwatch/README.md`](deploy/helm/northwatch/README.md)
+  for values reference.
 
-### What's next
-
-The v0.1.0 MVP installs as:
-
-```sh
-helm install northwatch oci://ghcr.io/northwatchlabs/charts/northwatch \
-  --version <x.y.z> --values your-config.yaml
-```
-
-Tracking issues for the full incident-management story (live banner
-driven by `POST /incidents`) and the Helm chart are in the
-[v0.1.0 milestone](https://github.com/northwatchlabs/northwatch/milestone/1).
+The roadmap for v0.2.0+ (Postgres, external HTTP monitors,
+notifications, CLI, OCI-published chart) lives in the
+[GitHub milestones](https://github.com/northwatchlabs/northwatch/milestones).
 
 See [`docs/conventions.md`](docs/conventions.md) for the foundational
 naming decisions (Go module path, container registry, Helm OCI path)


### PR DESCRIPTION
## Summary

The root README still framed the project as pre-v0.1.0, documented
an install command that doesn't work (the OCI chart at
`oci://ghcr.io/northwatchlabs/charts/northwatch` isn't published —
deferred to v0.2+), and never walked through the incident-banner
flow that is the killer demo. Replace with two quickstart paths
that actually work today:

- **Quickstart — Helm**: installs from the in-tree chart, pinned
  to the freshly-published `0.1.0` image tag, plus the curl-based
  killer demo (open incident → red banner → resolve → banner
  clears).
- **Quickstart — binary**: the previous local-binary flow, kept
  for development and non-K8s use, with the `NORTHWATCH_API_TOKEN`
  note added.

Also drops the stale pre-v0.1.0 banner, links the published
container image + Release artifacts, replaces the closed-milestone
link with the milestones index, and adds a "What's shipped in
v0.1.0" summary section.

Standalone polish PR — no linked issue.

## Test plan

- [x] Helm quickstart commands reflect the actual chart path
      (`./deploy/helm/northwatch`) and existing values (`image.tag`,
      `--set-file config=...`, auto-generated `auth.token`)
- [x] Incident POST payload uses the real JSON field name
      (`component`, not `component_id`) — verified against
      `internal/server/incidents.go:apiIncident`
- [x] Component ID format (`Kind/namespace/name`) matches the
      `examples/basic/northwatch.yaml` entries
- [x] Bearer-token retrieval command matches the chart's secret
      naming (`<release>-northwatch-api-token`)
- [x] Existing Develop / mise setup section preserved verbatim
- [x] HelmRelease and Kustomization optional walkthroughs preserved
      verbatim

## Breaking changes

- [ ] This PR introduces a breaking change

## PR Checklist

- [ ] Branch rebased on latest `origin/main` with commits squashed
- [x] Issue, if exists, is linked
- [x] Pre-merge Test plan items checked off
- [ ] All reviewer comments resolved