### PR TITLE
Add initial contributor docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,10 @@ The roadmap for v0.2.0+ (Postgres, external HTTP monitors,
 notifications, CLI, OCI-published chart) lives in the
 [GitHub milestones](https://github.com/northwatchlabs/northwatch/milestones).
 
+Contributor documentation starts in [`docs/index.md`](docs/index.md):
+architecture, status derivation, data model, GitOps behavior, local
+setup, and release process.
+
 See [`docs/development/conventions.md`](docs/development/conventions.md) for the foundational
 naming decisions (Go module path, container registry, Helm OCI path)
 that downstream tooling depends on.

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -1,0 +1,115 @@
+# Data Model
+
+The domain model is small and mirrors the SQLite schema. Components
+represent watched resources. Incidents represent operator-declared
+events affecting a component. Incident updates record the timeline for
+an incident.
+
+```mermaid
+erDiagram
+  COMPONENTS ||--o{ INCIDENTS : has
+  INCIDENTS ||--o{ INCIDENT_UPDATES : records
+  COMPONENTS ||--o{ STATUS_HISTORY : summarizes
+
+  COMPONENTS {
+    text kind
+    text namespace
+    text name
+    text id
+    text display_name
+    text status
+    integer updated_at
+    integer active
+  }
+
+  INCIDENTS {
+    text id
+    text component_id
+    text title
+    text status
+    integer opened_at
+    integer resolved_at
+  }
+
+  INCIDENT_UPDATES {
+    text id
+    text incident_id
+    text body
+    text status
+    integer created_at
+  }
+
+  STATUS_HISTORY {
+    text component_id
+    integer day
+    text status
+    integer downtime_seconds
+  }
+```
+
+## Components
+
+The canonical component ID is:
+
+```text
+<kind>/<namespace>/<name>
+```
+
+SQLite stores `components.id` as a generated column from those three
+fields. The same format is returned by `component.Component.ID()` and
+used by watchers, incidents, and API responses.
+
+Component status is one of:
+
+- `unknown`
+- `operational`
+- `degraded`
+- `down`
+
+`updated_at` is written by the store when status is upserted. It tracks
+status update time, not config sync time.
+
+`active` separates current desired components from historical rows.
+When a component disappears from config, `SyncComponents` can
+soft-deactivate it with `active=0` instead of deleting it. Public list
+queries return only active components.
+
+## Incidents
+
+Incidents are tied to components by `component_id`. The service refuses
+to create an incident for a missing or inactive component.
+
+Incident status is one of:
+
+- `investigating`
+- `identified`
+- `monitoring`
+- `resolved`
+
+The current write surface creates incidents and resolves incidents.
+`CreateIncident` inserts the incident and its first timeline row in a
+single transaction. `ResolveIncident` marks the incident resolved and
+inserts a resolved timeline row in a single transaction.
+
+## Incident updates
+
+`incident_updates` is the timeline table. It is already part of the
+schema, and the create/resolve paths write to it. A general
+`POST /incidents/:id/updates` endpoint is a later v0.2 task.
+
+## Status history
+
+`status_history` is reserved for daily availability summaries. The
+table exists now so migrations can evolve safely, but current v0.1
+watcher writes do not populate it. Issue #74 tracks populating this
+table on component state transitions.
+
+## Persistence contracts
+
+The `store.Store` interface is the boundary for persistence. New code
+should depend on that interface unless it is inside the SQLite
+implementation or a migration test.
+
+SQLite migrations are embedded from `internal/store/migrations`.
+`northwatch serve` applies them on startup. `northwatch migrate` applies
+them and exits.

--- a/docs/architecture/gitops.md
+++ b/docs/architecture/gitops.md
@@ -1,0 +1,76 @@
+# GitOps Model
+
+NorthWatch treats config as desired state. A component appears on the
+status page because it is declared in `northwatch.yaml`, and its health
+comes from the live Kubernetes resource with the same kind, namespace,
+and name.
+
+```yaml
+components:
+  - kind: Deployment
+    namespace: default
+    name: api-gateway
+    displayName: "API Gateway"
+```
+
+Supported kinds today:
+
+- `Deployment`
+- `HelmRelease`
+- `Kustomization`
+- `Application`
+
+`displayName` is optional. When it is omitted, NorthWatch uses `name`.
+
+## Startup reconciliation
+
+On boot, `cmd/northwatch` loads the config and calls
+`Store.SyncComponents` with the desired component set.
+
+The sync runs in one SQLite transaction:
+
+- desired rows that do not exist are inserted as `unknown`
+- desired rows that already exist keep their status and become active
+- display names are updated from config
+- rows no longer declared can be soft-deactivated
+
+Soft-deactivation is gated. If config would remove active components,
+NorthWatch refuses to boot unless `--allow-deactivate` or
+`NORTHWATCH_ALLOW_DEACTIVATE=true` is set. This protects operators from
+accidentally wiping the public watched set with a bad config file.
+
+## Runtime reconciliation
+
+After startup, watchers reconcile status from cluster events. The config
+does not carry health. It only declares the resources NorthWatch should
+pay attention to.
+
+Each watcher filters events to configured namespaced names. Unconfigured
+objects are ignored, even if the informer sees them. Configured objects
+are mapped into NorthWatch component statuses and written to the store
+after debounce rules are applied.
+
+## Optional controllers
+
+GitOps controllers are optional. A cluster can run only Deployments and
+NorthWatch still serves normally.
+
+Flux and ArgoCD watchers start only when their CRDs are present:
+
+- Flux HelmRelease CRD present -> start HelmRelease watcher
+- Flux Kustomization CRD present -> start Kustomization watcher
+- ArgoCD Application CRD present -> start Application watcher
+
+If a configured component refers to a kind whose CRD is absent, that
+component remains at its stored status, commonly `unknown`, until a
+matching watcher exists and observes it.
+
+## No manual pings
+
+NorthWatch does not ask operators to configure arbitrary HTTP checks for
+Kubernetes workloads in the MVP. The wedge is resource-native health:
+controller status is the source of truth.
+
+External monitors are planned for a later phase. Keep the current
+GitOps docs focused on declared resources, controller reconciliation,
+and status conditions.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -1,3 +1,17 @@
 # Architecture
 
-Coming soon - tracked in #54.
+NorthWatch keeps the MVP architecture deliberately small:
+
+- one Go command in `cmd/northwatch`
+- one config file, parsed by `internal/config`
+- one persistence interface in `internal/store`
+- resource-specific Kubernetes watchers in `internal/watcher`
+- status mapping and debouncing in `internal/status`
+- HTTP routes and templates in `internal/server` and `internal/ui`
+
+Read these pages in order when changing runtime behavior:
+
+1. [Overview](overview.md)
+2. [Status derivation](status-derivation.md)
+3. [Data model](data-model.md)
+4. [GitOps model](gitops.md)

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,67 @@
+# Architecture Overview
+
+NorthWatch is a single Go process. `cmd/northwatch` owns startup:
+parse flags, open SQLite, apply migrations, load `northwatch.yaml`,
+sync the desired component set, build the Kubernetes client, start the
+HTTP server, and launch resource watchers.
+
+```mermaid
+flowchart LR
+  config["northwatch.yaml"] --> cmd["cmd/northwatch"]
+  cmd --> store["internal/store<br/>SQLite + migrations"]
+  cmd --> server["internal/server<br/>chi routes"]
+  cmd --> watchers["internal/watcher<br/>Kubernetes informers"]
+  watchers --> status["internal/status<br/>mapping + debounce"]
+  status --> store
+  server --> store
+  server --> ui["internal/ui<br/>embedded templates + static assets"]
+  ui --> page["public status page"]
+```
+
+## Runtime pieces
+
+`cmd/northwatch` is the composition root. It supports `serve` and
+`migrate`. If no subcommand is passed, `serve` is used. The server
+defaults are intentionally local-friendly: `:8080` for HTTP,
+`./northwatch.db` for SQLite, and `northwatch.yaml` for config.
+
+`internal/config` parses and validates the component declaration file.
+It accepts `Deployment`, `HelmRelease`, `Kustomization`, and
+`Application`. The config package is a leaf package; translation into
+store shapes happens in `cmd/northwatch`.
+
+`internal/store` defines the persistence contract. SQLite is the only
+implementation today. The store owns migrations, component upserts,
+component config sync, incident creation, incident resolution, and
+read APIs used by the HTTP layer.
+
+`internal/watcher` owns Kubernetes integration. The Deployment watcher
+uses typed client-go informers. Flux and ArgoCD resources use dynamic
+informers gated by CRD discovery probes so clusters without those CRDs
+can still boot.
+
+`internal/status` contains pure status mapping plus the downward
+transition debouncer. Watchers call into this package before writing
+component state to the store.
+
+`internal/server` wires chi routes. Reads are public. Incident writes
+are protected by a bearer token. The public page is server-rendered
+HTML; the status section refreshes through HTMX polling.
+
+`internal/ui` embeds Go templates, compiled Tailwind CSS, and HTMX so
+the binary can run without external static files.
+
+## Package direction
+
+The architecture is intentionally one-way:
+
+- config, component, incident, and status packages do not depend on
+  HTTP or Kubernetes wiring.
+- watchers depend on config, status, component, and store.
+- server depends on store and incident service interfaces, not on
+  watcher internals.
+- cmd depends on everything because it assembles the process.
+
+Keep new behavior close to the package that owns it. For example,
+status interpretation belongs in `internal/status`, while informer
+event handling belongs in `internal/watcher`.

--- a/docs/architecture/status-derivation.md
+++ b/docs/architecture/status-derivation.md
@@ -1,0 +1,97 @@
+# Status Derivation
+
+NorthWatch derives component health from Kubernetes resource state.
+The YAML config decides which resources are watched; the cluster
+decides the current status.
+
+```mermaid
+sequenceDiagram
+  participant Config as northwatch.yaml
+  participant Cmd as cmd/northwatch
+  participant Store as SQLite store
+  participant Watcher as resource watcher
+  participant Mapper as status mapper
+  participant UI as HTMX status page
+
+  Config->>Cmd: load and validate components
+  Cmd->>Store: SyncComponents(desired set)
+  Cmd->>Watcher: start informers for configured kinds
+  Watcher->>Watcher: ignore unconfigured resource events
+  Watcher->>Mapper: map resource status to component status
+  Mapper->>Watcher: unknown / operational / degraded / down
+  Watcher->>Watcher: debounce downward transitions
+  Watcher->>Store: UpsertComponent(status)
+  UI->>Store: poll /api/status every N seconds
+```
+
+## Source kinds
+
+`Deployment` uses `apps/v1` typed informers and maps from
+`status.conditions` plus replica readiness:
+
+- `Progressing=True`, `reason=NewReplicaSetAvailable`, and ready
+  replicas at least desired replicas -> `operational`
+- `Progressing=False`, `reason=ProgressDeadlineExceeded` -> `down`
+- ready replicas `0` -> `down`
+- ready replicas below desired replicas -> `degraded`
+- otherwise -> `operational`
+
+Flux `HelmRelease` and Flux `Kustomization` use kstatus-style
+conditions. NorthWatch checks fresh `Stalled`, `Ready`, and
+`Reconciling` conditions in that order:
+
+- `Stalled=True` -> `down`
+- `Ready=True` -> `operational`
+- `Ready=False`, `reason=Progressing` -> `degraded`
+- `Ready=False` with another reason -> `down`
+- `Reconciling=True` -> `degraded`
+- no trusted signal -> `unknown`
+
+A condition is trusted when `observedGeneration` is absent or is at
+least the resource generation. This supports older controllers that do
+not stamp `observedGeneration` while ignoring explicitly stale
+conditions.
+
+ArgoCD `Application` maps from `status.health.status`:
+
+- `Healthy` -> `operational`
+- `Progressing` -> `degraded`
+- `Degraded` or `Missing` -> `down`
+- `Unknown`, missing, empty, or unrecognized -> `unknown`
+- `Suspended` preserves the previous stored status and writes nothing
+
+## CRD discovery
+
+Deployment watching is always available when Kubernetes access works.
+Flux and ArgoCD watchers are optional:
+
+- `HelmRelease` probes the served Flux HelmRelease API versions and
+  picks the newest supported version.
+- `Kustomization` probes for
+  `kustomize.toolkit.fluxcd.io/v1/kustomizations`.
+- `Application` probes for `argoproj.io/v1alpha1/applications`.
+
+Missing CRDs are normal. NorthWatch logs that the watcher is skipped
+and continues serving the remaining components.
+
+## Debounce rules
+
+Each watcher owns its own debouncer. The default window is 60 seconds
+and can be changed with `--debounce-seconds` or
+`NORTHWATCH_DEBOUNCE_SECONDS`.
+
+Downward transitions are held for the debounce window to avoid page
+flicker during rollouts. Upward transitions write immediately.
+Transitions involving `unknown` also write immediately because losing
+or regaining signal is meaningful on its own.
+
+When the debounce timer fires, the watcher re-reads the object from
+the informer lister and remaps current state before writing. If the
+object disappeared, the pending entry is forgotten.
+
+## UI refresh path
+
+The status page is not pushed by the watchers. Watchers only update
+SQLite. The browser polls `/api/status` with HTMX every
+`PollSeconds` seconds and swaps the rendered status section. The
+default poll interval is 5 seconds.

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -1,3 +1,11 @@
 # Development
 
-Coming soon - tracked in #54.
+NorthWatch uses `mise` to pin development tools. Start with
+[Local setup](local-setup.md), then use the project `Makefile` for the
+common Go, CSS, image, Helm, and e2e loops.
+
+Development references:
+
+- [Local setup](local-setup.md)
+- [Release process](release-process.md)
+- [Project conventions](conventions.md)

--- a/docs/development/local-setup.md
+++ b/docs/development/local-setup.md
@@ -1,0 +1,128 @@
+# Local Setup
+
+NorthWatch contributors should use the tool versions pinned in
+`mise.toml`. The pinned tools include Go, Python for MkDocs, Tailwind,
+kind, kubectl, kubectx, Flux, Helm, goreleaser, and golangci-lint.
+
+## Bootstrap tools
+
+Install `mise`, activate it in your shell, then install project tools:
+
+```sh
+brew install mise
+mise trust
+mise install
+```
+
+The docs tasks create a local Python virtual environment at
+`.venv-docs`.
+
+## Common commands
+
+```sh
+make build       # build ./cmd/northwatch into ./northwatch
+make test        # run unit tests
+make vet         # run go vet
+make lint        # run golangci-lint
+make css         # compile Tailwind into embedded style.css
+make image       # build a local container image
+make helm-lint   # lint the in-tree chart
+mise run docs-build
+```
+
+`mise run docs-build` runs `mkdocs build --strict` after installing
+`docs/requirements.txt`.
+
+## Run without a cluster
+
+Use `--no-cluster` when working on HTTP, template, incident, config, or
+store behavior that does not require informers:
+
+```sh
+mise trust
+mise install
+make build
+
+cat > /tmp/northwatch.yaml <<'EOF'
+components:
+  - kind: Deployment
+    namespace: default
+    name: api-gateway
+    displayName: "API Gateway"
+EOF
+
+./northwatch serve \
+  --no-cluster \
+  --config /tmp/northwatch.yaml \
+  --db /tmp/northwatch.db
+```
+
+Open <http://localhost:8080>. Components will stay `unknown` because
+no watcher is connected to a cluster.
+
+## Run against kind
+
+Use kind when touching watcher behavior, the Helm chart, or the
+container image.
+
+```sh
+mise trust
+mise install
+
+kind create cluster --name nw-demo
+kubectl --context kind-nw-demo apply -f examples/basic/sample-deployment.yaml
+
+make build
+./northwatch serve \
+  --config examples/basic/northwatch.yaml \
+  --db /tmp/nw-demo.db \
+  --kubeconfig ~/.kube/config \
+  --kube-context kind-nw-demo \
+  --allow-deactivate
+```
+
+Open <http://localhost:8080>. `Deployment/default/api-gateway` should
+move to `operational` once the deployment is available.
+
+Clean up with:
+
+```sh
+kind delete cluster --name nw-demo
+```
+
+## Incident write endpoints
+
+Read endpoints are public. POST endpoints require a bearer token with
+at least 16 characters.
+
+```sh
+export NORTHWATCH_API_TOKEN=dev-token-123456
+./northwatch serve --no-cluster --config /tmp/northwatch.yaml --db /tmp/northwatch.db
+```
+
+If the token is empty, NorthWatch serves reads and returns 401 for
+writes. If the token is present but shorter than 16 characters, boot
+fails.
+
+## Database files
+
+The binary default SQLite path is `./northwatch.db`. Pass `--db` or set
+`NORTHWATCH_DB` to keep local runs isolated.
+
+The container image defaults to
+`/var/lib/northwatch/northwatch.db`. Mount a volume there when testing
+container persistence across restarts.
+
+## Watcher development
+
+Watcher changes need Kubernetes tests or a local cluster check. Unit
+tests cover mapping and informer behavior with fakes; the e2e path
+uses kind, Docker, and the Helm chart:
+
+```sh
+make e2e
+```
+
+The e2e loop creates a kind cluster, builds and loads the image, runs
+the killer-demo tests, and removes the cluster unless
+`E2E_KEEP_CLUSTER` is set.

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -1,0 +1,95 @@
+# Release Process
+
+NorthWatch ships from GitHub Actions. Contributors usually interact
+with the verification workflows on pull requests; maintainers cut
+releases by pushing `v*` tags.
+
+## Pull request verification
+
+The main PR workflow runs:
+
+- `go vet ./...`
+- `go test -race ./...`
+- golangci-lint
+- cross-platform builds for linux and darwin on amd64 and arm64
+- a goreleaser snapshot build
+
+Additional workflows verify:
+
+- MkDocs strict build when docs change
+- container image build, smoke test, non-root runtime assertion, and
+  multi-arch build validation
+- Helm chart lint and smoke tests with Helm 3 and Helm 4
+- killer-demo e2e tests in kind
+
+Run the focused local equivalent before pushing changes. For docs-only
+changes, `mise run docs-build` is usually enough. For Go behavior,
+run `make test` plus the narrower commands relevant to the touched
+surface.
+
+## Binaries
+
+`.goreleaser.yaml` builds the `northwatch` binary from
+`./cmd/northwatch` for:
+
+- linux/amd64
+- linux/arm64
+- darwin/amd64
+- darwin/arm64
+
+Release archives are `tar.gz` files and the release includes
+`checksums.txt`. GitHub releases are created as drafts.
+
+The release workflow runs goreleaser on pushed `v*` tags. Manual
+workflow dispatch runs a snapshot dry run and skips publishing.
+
+## Container image
+
+The image workflow builds from `deploy/docker/Dockerfile` and publishes
+to:
+
+```text
+ghcr.io/northwatchlabs/northwatch
+```
+
+Published tags include branch, SHA, semver, major/minor, and `latest`
+for the default branch. Published images are signed with cosign keyless
+OIDC.
+
+The Dockerfile builds a static Go binary with `CGO_ENABLED=0`, copies
+it into a distroless non-root runtime image, and defaults SQLite to:
+
+```text
+/var/lib/northwatch/northwatch.db
+```
+
+## Helm chart
+
+The in-tree chart lives at `deploy/helm/northwatch`. Chart verification
+uses `helm lint`, builds a matching NorthWatch image from the chart
+`appVersion`, installs the chart into kind, waits for the deployment,
+checks `/healthz`, checks component status through `/api/components`,
+and verifies cluster-scoped RBAC is removed on uninstall.
+
+The project convention for the future OCI chart path is:
+
+```text
+oci://ghcr.io/northwatchlabs/charts/northwatch
+```
+
+See [Project conventions](conventions.md) before changing public names,
+registry paths, module paths, or chart paths.
+
+## Docs site
+
+Docs are built with MkDocs Material. Pull requests run
+`mkdocs build --strict` through `mise run docs-build` when docs-related
+paths change.
+
+Merges to `main` deploy the docs site through:
+
+```sh
+mise run docs-deploy
+```
+
+The deploy workflow publishes to GitHub Pages with `mkdocs gh-deploy`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,43 @@
 # NorthWatch
 
-Coming soon - tracked in #54.
+NorthWatch is a single-binary status page for Kubernetes and GitOps
+workloads. It reads a small YAML config, watches the matching cluster
+resources, derives component health from resource status, and renders a
+public status page with incident banners.
+
+This documentation is for contributors working on NorthWatch itself.
+It explains the current architecture, the status-derivation path, the
+data model, the GitOps contract, and the local development loop.
+
+## Start here
+
+- [Architecture overview](architecture/overview.md) explains the main
+  packages and runtime process.
+- [Status derivation](architecture/status-derivation.md) explains how
+  Kubernetes and GitOps resource status becomes component health.
+- [Data model](architecture/data-model.md) explains the SQLite tables
+  and domain objects.
+- [GitOps model](architecture/gitops.md) explains how `northwatch.yaml`
+  is reconciled.
+- [Local setup](development/local-setup.md) covers tool bootstrap and
+  common development commands.
+- [Release process](development/release-process.md) summarizes CI,
+  images, binaries, Helm, and docs publishing.
+
+## Current product scope
+
+NorthWatch v0.1 ships:
+
+- watched components declared in `northwatch.yaml`
+- source kinds: `Deployment`, Flux `HelmRelease`, Flux
+  `Kustomization`, and ArgoCD `Application`
+- status states: `unknown`, `operational`, `degraded`, `down`
+- SQLite persistence with embedded migrations
+- server-rendered HTML with HTMX polling
+- bearer-token-protected incident create and resolve endpoints
+- a container image and an in-tree Helm chart
+
+Postgres, external monitors, notification channels, a separate CLI,
+subscribers, NorthWatch-owned CRDs, and operator-managed resources are
+later roadmap items. Do not build contributor docs around those
+surfaces until the code exists.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,7 +40,14 @@ markdown_extensions:
 
 nav:
   - Home: index.md
-  - Architecture: architecture/index.md
+  - Architecture:
+      - architecture/index.md
+      - Overview: architecture/overview.md
+      - Status Derivation: architecture/status-derivation.md
+      - Data Model: architecture/data-model.md
+      - GitOps Model: architecture/gitops.md
   - Development:
       - development/index.md
+      - Local Setup: development/local-setup.md
+      - Release Process: development/release-process.md
       - Conventions: development/conventions.md


### PR DESCRIPTION
## Summary
- Adds the initial contributor-facing MkDocs pages for architecture, status derivation, data model, GitOps behavior, local setup, and release process.
- Documents current v0.1 behavior from the codebase: SQLite persistence, HTMX polling, config-driven component sync, and Kubernetes watcher status mapping.
- Wires the pages into MkDocs navigation and adds a README entry point.

Closes #54

## Test plan
- [x] `mise run docs-build`
- [x] `git diff --check origin/main..HEAD`
- [x] `rg -n "Coming soon|tracked in #54|Badger|SSE|TODO|TBD" docs README.md mkdocs.yml`
