### PR TITLE
Reject explicitly empty API tokens

### DIFF
--- a/cmd/northwatch/main.go
+++ b/cmd/northwatch/main.go
@@ -70,7 +70,7 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "  --no-cluster       Skip cluster connectivity (local-only run)")
 	fmt.Fprintln(os.Stderr, "  --api-token        Bearer token for write endpoints (>=16 chars).")
 	fmt.Fprintln(os.Stderr, "                     Reads NORTHWATCH_API_TOKEN env when unset.")
-	fmt.Fprintln(os.Stderr, "                     Empty disables writes (POSTs return 401).")
+	fmt.Fprintln(os.Stderr, "                     Omit to disable writes (POSTs return 401).")
 	fmt.Fprintln(os.Stderr, "  --poll-seconds     HTMX polling interval in seconds (default 5)")
 	fmt.Fprintln(os.Stderr, "  --debounce-seconds Grace period before downward status transitions are persisted")
 	fmt.Fprintln(os.Stderr, "                     (>=0; default 60; 0 disables debounce)")
@@ -95,9 +95,7 @@ func serveCmd(args []string) int {
 	noCluster := fs.Bool("no-cluster",
 		envOrBool("NORTHWATCH_NO_CLUSTER", false),
 		"Skip cluster connectivity (local-only run)")
-	apiToken := fs.String("api-token",
-		envOr("NORTHWATCH_API_TOKEN", ""),
-		"Bearer token gating POST endpoints (>=16 chars). Empty disables writes.")
+	apiToken := fs.String("api-token", "", "Bearer token gating POST endpoints (>=16 chars). Omit to disable writes.")
 	pollSeconds := fs.Int("poll-seconds",
 		envOrInt("NORTHWATCH_POLL_SECONDS", 5),
 		"HTMX polling interval in seconds (>=1)")
@@ -112,6 +110,13 @@ func serveCmd(args []string) int {
 	}
 
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+
+	resolvedAPIToken, err := resolveAPIToken(fs)
+	if err != nil {
+		logger.Error("api token configured empty")
+		return 1
+	}
+	*apiToken = resolvedAPIToken
 
 	switch {
 	case *apiToken == "":
@@ -268,6 +273,32 @@ func envOr(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+func resolveAPIToken(fs *flag.FlagSet) (string, error) {
+	var flagSet bool
+	var flagValue string
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "api-token" {
+			flagSet = true
+			flagValue = f.Value.String()
+		}
+	})
+	if flagSet {
+		if flagValue == "" {
+			return "", errors.New("api token configured empty")
+		}
+		return flagValue, nil
+	}
+
+	v, ok := os.LookupEnv("NORTHWATCH_API_TOKEN")
+	if !ok {
+		return "", nil
+	}
+	if v == "" {
+		return "", errors.New("api token configured empty")
+	}
+	return v, nil
 }
 
 // envOrBool reads a bool-ish env var. "1", "true", "yes"

--- a/cmd/northwatch/main_test.go
+++ b/cmd/northwatch/main_test.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"context"
+	"flag"
 	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/northwatchlabs/northwatch/internal/store"
@@ -61,6 +63,28 @@ func writeConfig(t *testing.T, body string) string {
 
 func testLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Pipe: %v", err)
+	}
+	os.Stdout = w
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close pipe writer: %v", err)
+	}
+	os.Stdout = old
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("ReadAll stdout: %v", err)
+	}
+	return string(out)
 }
 
 const cfgAB = `
@@ -151,6 +175,57 @@ func TestRunConfigSync_MissingConfig(t *testing.T) {
 	_, code := runConfigSync(context.Background(), st, "/does/not/exist.yaml", false, testLogger())
 	if code != 1 {
 		t.Errorf("code = %d, want 1", code)
+	}
+}
+
+func TestResolveAPIToken(t *testing.T) {
+	cases := []struct {
+		name    string
+		envSet  bool
+		envVal  string
+		args    []string
+		want    string
+		wantErr bool
+	}{
+		{name: "unset env and absent flag disables writes", want: ""},
+		{name: "empty env is invalid", envSet: true, envVal: "", wantErr: true},
+		{name: "non-empty env is used", envSet: true, envVal: "env-token-123456", want: "env-token-123456"},
+		{name: "empty flag is invalid", envSet: true, envVal: "env-token-123456", args: []string{"--api-token", ""}, wantErr: true},
+		{name: "flag wins over env", envSet: true, envVal: "env-token-123456", args: []string{"--api-token", "flag-token-123456"}, want: "flag-token-123456"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			const key = "NORTHWATCH_API_TOKEN"
+			if tc.envSet {
+				t.Setenv(key, tc.envVal)
+			} else {
+				t.Setenv(key, "ignored")
+				if err := os.Unsetenv(key); err != nil {
+					t.Fatalf("Unsetenv: %v", err)
+				}
+			}
+
+			fs := flag.NewFlagSet("test", flag.ContinueOnError)
+			fs.String("api-token", "", "")
+			if err := fs.Parse(tc.args); err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+
+			got, err := resolveAPIToken(fs)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("resolveAPIToken() err = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveAPIToken() err = %v, want nil", err)
+			}
+			if got != tc.want {
+				t.Errorf("resolveAPIToken() = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 
@@ -278,7 +353,6 @@ func TestEnvOrInt(t *testing.T) {
 }
 
 func TestServeCmd_PollSecondsValidation(t *testing.T) {
-	t.Parallel()
 	cases := []struct {
 		name string
 		val  string
@@ -299,5 +373,75 @@ func TestServeCmd_PollSecondsValidation(t *testing.T) {
 				t.Errorf("serveCmd exit = %d, want %d", code, tc.want)
 			}
 		})
+	}
+}
+
+func TestServeCmd_RejectsExplicitEmptyAPIToken(t *testing.T) {
+	cases := []struct {
+		name   string
+		envSet bool
+		envVal string
+		args   []string
+	}{
+		{name: "empty env", envSet: true, envVal: ""},
+		{name: "empty flag", envSet: true, envVal: "valid-env-token-1234", args: []string{"--api-token", ""}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.envSet {
+				t.Setenv("NORTHWATCH_API_TOKEN", tc.envVal)
+			} else {
+				t.Setenv("NORTHWATCH_API_TOKEN", "ignored")
+				if err := os.Unsetenv("NORTHWATCH_API_TOKEN"); err != nil {
+					t.Fatalf("Unsetenv: %v", err)
+				}
+			}
+
+			args := []string{
+				"--no-cluster",
+				"--db", filepath.Join(t.TempDir(), "nw.db"),
+				"--config", writeConfig(t, cfgAB),
+				"--poll-seconds", "0",
+			}
+			args = append(args, tc.args...)
+
+			logOut := captureStdout(t, func() {
+				if code := serveCmd(args); code != 1 {
+					t.Errorf("serveCmd exit = %d, want 1", code)
+				}
+			})
+			if !strings.Contains(logOut, "api token configured empty") {
+				t.Errorf("log output = %s, want api token configured empty", logOut)
+			}
+			if strings.Contains(logOut, "poll-seconds must be >= 1") {
+				t.Errorf("log output = %s, token validation should run before poll validation", logOut)
+			}
+		})
+	}
+}
+
+func TestServeCmd_OmittedAPITokenReachesLaterValidation(t *testing.T) {
+	t.Setenv("NORTHWATCH_API_TOKEN", "ignored")
+	if err := os.Unsetenv("NORTHWATCH_API_TOKEN"); err != nil {
+		t.Fatalf("Unsetenv: %v", err)
+	}
+
+	logOut := captureStdout(t, func() {
+		code := serveCmd([]string{
+			"--no-cluster",
+			"--db", filepath.Join(t.TempDir(), "nw.db"),
+			"--config", writeConfig(t, cfgAB),
+			"--poll-seconds", "0",
+		})
+		if code != 1 {
+			t.Errorf("serveCmd exit = %d, want 1", code)
+		}
+	})
+	if !strings.Contains(logOut, "poll-seconds must be >= 1") {
+		t.Errorf("log output = %s, want poll-seconds validation", logOut)
+	}
+	if strings.Contains(logOut, "api token configured empty") {
+		t.Errorf("log output = %s, omitted token should not be rejected as configured empty", logOut)
 	}
 }

--- a/deploy/helm/northwatch/README.md
+++ b/deploy/helm/northwatch/README.md
@@ -46,7 +46,9 @@ The chart resolves the API token in this order:
 
 1. `auth.existingSecret` — the chart does not render its own Secret;
    the Deployment references `secretKeyRef: {name: <existingSecret>,
-   key: <existingSecretKey>}`.
+   key: <existingSecretKey>}`. The referenced key must contain a
+   non-empty token value; an empty value causes NorthWatch startup to
+   fail instead of disabling incident writes.
 2. `auth.token` — the chart renders a Secret with the literal value.
 3. Neither set — the chart auto-generates a 32-char alphanumeric token
    on first install and preserves it across `helm upgrade` via

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,8 +53,9 @@ Common `serve` flags:
 | `--poll-seconds` | `NORTHWATCH_POLL_SECONDS` | `5` |
 | `--debounce-seconds` | `NORTHWATCH_DEBOUNCE_SECONDS` | `60` |
 
-`--api-token` must be empty or at least 16 characters. Empty disables
-write endpoints; public reads still work.
+`--api-token` and `NORTHWATCH_API_TOKEN` must be omitted or at least 16
+characters. Omission disables write endpoints; public reads still work.
+A configured empty token is invalid and NorthWatch refuses to boot.
 
 ## Safe component removal
 

--- a/docs/contributing/local-setup.md
+++ b/docs/contributing/local-setup.md
@@ -100,9 +100,10 @@ export NORTHWATCH_API_TOKEN=dev-token-123456
 ./northwatch serve --no-cluster --config /tmp/northwatch.yaml --db /tmp/northwatch.db
 ```
 
-If the token is empty, NorthWatch serves reads and returns 401 for
-writes. If the token is present but shorter than 16 characters, boot
-fails.
+If the token is omitted, NorthWatch serves reads and returns 401 for
+writes. If `--api-token` or `NORTHWATCH_API_TOKEN` is configured but
+empty, boot fails. If the configured token is shorter than 16 characters,
+boot also fails.
 
 ## Database files
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,6 +37,11 @@ The chart resolves the token in this order:
 2. `auth.token`
 3. an auto-generated chart-managed Secret
 
+When using `auth.existingSecret`, the referenced key must contain a
+non-empty token value. A missing key prevents the pod from starting, and
+an empty value causes NorthWatch to fail startup instead of silently
+disabling incident writes.
+
 Retrieve the chart-managed token:
 
 ```sh

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -32,6 +32,13 @@ Incident writes require `Authorization: Bearer <token>`. The token is
 configured with `--api-token`, `NORTHWATCH_API_TOKEN`, or the Helm chart
 `auth` values.
 
+For binary/env/flag runs, omit the API token to disable incident writes.
+For Helm installs, omitting both `auth.existingSecret` and `auth.token`
+keeps writes enabled because the chart generates a token. If the token is
+configured with `--api-token`, `NORTHWATCH_API_TOKEN`, or Helm auth
+values, it must be non-empty and at least 16 characters;
+configured-empty tokens fail startup.
+
 Create an incident:
 
 ```sh

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -46,6 +46,10 @@ Subcommands:
 | `--poll-seconds` | `NORTHWATCH_POLL_SECONDS` | `5` |
 | `--debounce-seconds` | `NORTHWATCH_DEBOUNCE_SECONDS` | `60` |
 
+Omit the API token to disable write endpoints. If `--api-token` or
+`NORTHWATCH_API_TOKEN` is configured, the value must be non-empty and at
+least 16 characters.
+
 ## HTTP routes
 
 | Method | Path | Auth | Notes |


### PR DESCRIPTION
## Summary
- Distinguishes omitted API token configuration from explicitly empty token values at `serve` startup.
- Fails fast for `NORTHWATCH_API_TOKEN=` and `--api-token ""` before falling through to writes-disabled mode.
- Documents the unset-vs-empty distinction for binary/env/flag runs and Helm `auth.existingSecret` installs.

Docs impact: updated API token behavior in configuration, reference, operations, installation, local setup, and Helm chart README docs.

Closes #73

## Test plan
- [x] `go test ./cmd/northwatch -run TestResolveAPIToken -count=1` failed red with `undefined: resolveAPIToken`
- [x] `go test ./cmd/northwatch -run 'TestServeCmd_(RejectsExplicitEmptyAPIToken|OmittedAPITokenReachesLaterValidation)' -count=1` failed red before wiring with empty tokens reaching poll validation
- [x] `go test ./cmd/northwatch -count=1`
- [x] `go test ./...`
- [x] `helm lint deploy/helm/northwatch`
- [x] `mise run docs-build`
- [x] `git diff --check`
- [x] fresh-context implementation diff review approved