### PR TITLE
Return JSON API error envelopes

### DIFF
--- a/internal/server/api_error.go
+++ b/internal/server/api_error.go
@@ -1,0 +1,16 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type apiError struct {
+	Error string `json:"error"`
+}
+
+func writeJSONError(w http.ResponseWriter, code int, msg string) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(apiError{Error: msg})
+}

--- a/internal/server/incidents.go
+++ b/internal/server/incidents.go
@@ -57,7 +57,7 @@ func apiIncidentsHandler(svc *incident.Service, logger *slog.Logger) http.Handle
 		incs, err := svc.ListIncidents(r.Context(), includeResolved)
 		if err != nil {
 			logger.Error("api/incidents: ListIncidents failed", "err", err)
-			http.Error(w, "store error", http.StatusInternalServerError)
+			writeJSONError(w, http.StatusInternalServerError, "store error")
 			return
 		}
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
@@ -98,19 +98,13 @@ func createIncidentHandler(svc *incident.Service, logger *slog.Logger) http.Hand
 			return
 		case err != nil:
 			logger.Error("incidents: CreateIncident failed", "err", err)
-			http.Error(w, "store error", http.StatusInternalServerError)
+			writeJSONError(w, http.StatusInternalServerError, "store error")
 			return
 		}
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(http.StatusCreated)
 		_ = json.NewEncoder(w).Encode(toAPIIncident(inc))
 	}
-}
-
-func writeJSONError(w http.ResponseWriter, code int, msg string) {
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	w.WriteHeader(code)
-	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
 }
 
 // resolveIncidentHandler serves POST /incidents/{id}/resolve.
@@ -127,7 +121,7 @@ func resolveIncidentHandler(svc *incident.Service, logger *slog.Logger) http.Han
 			return
 		case err != nil:
 			logger.Error("incidents/resolve: failed", "err", err)
-			http.Error(w, "store error", http.StatusInternalServerError)
+			writeJSONError(w, http.StatusInternalServerError, "store error")
 			return
 		}
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -100,13 +100,13 @@ func statusSectionHandler(tmpl *template.Template, st store.Store, incSvc *incid
 		data, err := loadPageData(r.Context(), st, incSvc, pollSeconds)
 		if err != nil {
 			logger.Error("api/status: loadPageData failed", "err", err)
-			http.Error(w, "store error", http.StatusInternalServerError)
+			writeJSONError(w, http.StatusInternalServerError, "store error")
 			return
 		}
 		var buf bytes.Buffer
 		if err := tmpl.ExecuteTemplate(&buf, "status_section", data); err != nil {
 			logger.Error("api/status: render failed", "err", err)
-			http.Error(w, "render error", http.StatusInternalServerError)
+			writeJSONError(w, http.StatusInternalServerError, "render error")
 			return
 		}
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -189,7 +189,7 @@ func apiComponentsHandler(st store.Store, logger *slog.Logger) http.HandlerFunc 
 		comps, err := st.ListComponents(r.Context())
 		if err != nil {
 			logger.Error("api/components: ListComponents failed", "err", err)
-			http.Error(w, "store error", http.StatusInternalServerError)
+			writeJSONError(w, http.StatusInternalServerError, "store error")
 			return
 		}
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -59,6 +59,26 @@ func newHandler(t *testing.T, seed ...component.Component) http.Handler {
 	return h
 }
 
+func assertJSONError(t *testing.T, rr *httptest.ResponseRecorder, code int, msg string) {
+	t.Helper()
+	if rr.Code != code {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, code, rr.Body.String())
+	}
+	if ct := rr.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Fatalf("content-type = %q, want application/json prefix", ct)
+	}
+	var got map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode error body: %v; body=%s", err, rr.Body.String())
+	}
+	if got["error"] != msg {
+		t.Fatalf("error = %q, want %q; body=%s", got["error"], msg, rr.Body.String())
+	}
+	if len(got) != 1 {
+		t.Fatalf("error body keys = %v, want only error", got)
+	}
+}
+
 func TestIndexReturnsStatusPage(t *testing.T) {
 	h := newHandler(t)
 	rr := httptest.NewRecorder()
@@ -202,6 +222,34 @@ func (failingStore) ListComponents(ctx context.Context) ([]component.Component, 
 	return nil, errors.New("synthetic store failure")
 }
 
+type failingIncidentListStore struct{ store.Store }
+
+func (failingIncidentListStore) ListIncidents(ctx context.Context, includeResolved bool) ([]incident.Incident, error) {
+	return nil, errors.New("synthetic incident list failure")
+}
+
+type failingCreateIncidentStore struct{ store.Store }
+
+func (failingCreateIncidentStore) HasActiveComponent(ctx context.Context, id string) (bool, error) {
+	return true, nil
+}
+
+func (failingCreateIncidentStore) CreateIncident(ctx context.Context, inc incident.Incident, firstUpdate incident.Update) error {
+	return errors.New("synthetic create incident failure")
+}
+
+type failingResolveIncidentStore struct{ store.Store }
+
+func (failingResolveIncidentStore) ResolveIncident(
+	ctx context.Context,
+	id string,
+	resolvedAt time.Time,
+	updateID string,
+	updateBody string,
+) (incident.Incident, error) {
+	return incident.Incident{}, errors.New("synthetic resolve incident failure")
+}
+
 func TestAPIComponents_StoreError(t *testing.T) {
 	ctx := context.Background()
 	real, err := store.OpenSQLite(ctx, ":memory:")
@@ -221,9 +269,7 @@ func TestAPIComponents_StoreError(t *testing.T) {
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/components", nil))
 
-	if rr.Code != http.StatusInternalServerError {
-		t.Errorf("status = %d, want 500", rr.Code)
-	}
+	assertJSONError(t, rr, http.StatusInternalServerError, "store error")
 }
 
 // newHandlerWithStore returns the GET-only handler + the store for
@@ -330,6 +376,28 @@ func TestGetAPIIncidentsCacheControlNoStore(t *testing.T) {
 	}
 }
 
+func TestGetAPIIncidents_StoreError(t *testing.T) {
+	ctx := context.Background()
+	real, err := store.OpenSQLite(ctx, ":memory:")
+	if err != nil {
+		t.Fatalf("OpenSQLite: %v", err)
+	}
+	t.Cleanup(func() { _ = real.Close() })
+	if err := real.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	h, err := server.New(slog.New(slog.NewTextHandler(io.Discard, nil)),
+		failingIncidentListStore{Store: real}, "", 5)
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/incidents", nil))
+
+	assertJSONError(t, rr, http.StatusInternalServerError, "store error")
+}
+
 // postIncident is a small helper that POSTs a create-incident body
 // through the wired router, with the bearer token attached. Returns
 // the recorder so callers can assert on status and body.
@@ -424,6 +492,27 @@ func TestCreateIncidentHandlerMalformedJSON(t *testing.T) {
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", rr.Code)
 	}
+}
+
+func TestCreateIncidentHandler_StoreError(t *testing.T) {
+	ctx := context.Background()
+	real, err := store.OpenSQLite(ctx, ":memory:")
+	if err != nil {
+		t.Fatalf("OpenSQLite: %v", err)
+	}
+	t.Cleanup(func() { _ = real.Close() })
+	if err := real.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	h, err := server.New(slog.New(slog.NewTextHandler(io.Discard, nil)),
+		failingCreateIncidentStore{Store: real}, testToken, 5)
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+
+	rr := postIncident(t, h, `{"component":"Deployment/default/web","title":"Pods down"}`)
+
+	assertJSONError(t, rr, http.StatusInternalServerError, "store error")
 }
 
 func TestPostIncidentsRequiresAuth(t *testing.T) {
@@ -546,6 +635,27 @@ func TestPostIncidentsResolveNotFound(t *testing.T) {
 	if !strings.Contains(rr.Body.String(), "incident not found") {
 		t.Errorf("body = %s, want incident not found", rr.Body.String())
 	}
+}
+
+func TestResolveIncidentHandler_StoreError(t *testing.T) {
+	ctx := context.Background()
+	real, err := store.OpenSQLite(ctx, ":memory:")
+	if err != nil {
+		t.Fatalf("OpenSQLite: %v", err)
+	}
+	t.Cleanup(func() { _ = real.Close() })
+	if err := real.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	h, err := server.New(slog.New(slog.NewTextHandler(io.Discard, nil)),
+		failingResolveIncidentStore{Store: real}, testToken, 5)
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+
+	rr := resolveIncident(t, h, "01HXNOSUCHINCIDENT00000000", true)
+
+	assertJSONError(t, rr, http.StatusInternalServerError, "store error")
 }
 
 func TestPostIncidentsResolveIdempotent(t *testing.T) {
@@ -713,6 +823,28 @@ func TestApiStatus_PartialIncludesPollingAttrs(t *testing.T) {
 			t.Errorf("partial should not contain %q; body=%s", banned, body)
 		}
 	}
+}
+
+func TestApiStatus_StoreError(t *testing.T) {
+	ctx := context.Background()
+	real, err := store.OpenSQLite(ctx, ":memory:")
+	if err != nil {
+		t.Fatalf("OpenSQLite: %v", err)
+	}
+	t.Cleanup(func() { _ = real.Close() })
+	if err := real.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	h, err := server.New(slog.New(slog.NewTextHandler(io.Discard, nil)),
+		failingStore{Store: real}, "", 5)
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/status", nil))
+
+	assertJSONError(t, rr, http.StatusInternalServerError, "store error")
 }
 
 func TestApiStatus_RendersDegradedWhenComponentDown(t *testing.T) {

--- a/internal/server/status_internal_test.go
+++ b/internal/server/status_internal_test.go
@@ -1,0 +1,60 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"html/template"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/northwatchlabs/northwatch/internal/incident"
+	"github.com/northwatchlabs/northwatch/internal/store"
+)
+
+func assertInternalJSONError(t *testing.T, rr *httptest.ResponseRecorder, code int, msg string) {
+	t.Helper()
+	if rr.Code != code {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, code, rr.Body.String())
+	}
+	if ct := rr.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Fatalf("content-type = %q, want application/json prefix", ct)
+	}
+	var got map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode error body: %v; body=%s", err, rr.Body.String())
+	}
+	if got["error"] != msg {
+		t.Fatalf("error = %q, want %q; body=%s", got["error"], msg, rr.Body.String())
+	}
+	if len(got) != 1 {
+		t.Fatalf("error body keys = %v, want only error", got)
+	}
+}
+
+func TestStatusSectionHandler_RenderError(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.OpenSQLite(ctx, ":memory:")
+	if err != nil {
+		t.Fatalf("OpenSQLite: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	tmpl := template.Must(template.New("test").Parse(
+		`{{define "status_section"}}{{template "missing" .}}{{end}}`,
+	))
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	incSvc := incident.NewService(st, logger)
+	h := statusSectionHandler(tmpl, st, incSvc, 5, logger)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/status", nil))
+
+	assertInternalJSONError(t, rr, http.StatusInternalServerError, "render error")
+}


### PR DESCRIPTION
## Summary
- Standardizes API store/render failures on the existing JSON envelope shape.
- Adds a shared server helper for {"error":"..."} responses.
- Covers component, incident, status partial, create, and resolve failure paths.

Docs impact: none

Closes #36

## Test plan
- [x] mise exec -- go test ./internal/server
- [x] mise exec -- go test ./...