### PR TITLE
Document API errors and docs-impact review

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,10 @@ Closes # or Part of #
 <!-- How this was / will be verified. Include pre-merge and post-merge checks (e.g. smoke test in target env, dashboard check) when applicable. -->
 - [ ]
 
+## Docs impact
+<!-- Required. Say which docs changed, or `none` with a brief reason after reviewing current docs. -->
+Docs impact:
+
 ## Breaking changes
 <!-- Tick the box if this PR introduces any breaking change. If yes,
 describe the break and any migration steps. Examples: removed or
@@ -20,6 +24,7 @@ version. -->
 ## PR Checklist
 - [ ] Branch rebased on latest `origin/main` with commits squashed
 - [ ] Issue, if exists, is linked
+- [ ] Documentation impact reviewed; docs updated or `Docs impact: none` justified
+- [ ] If docs changed, `mise run docs-build` passed
 - [ ] Pre-merge Test plan items checked off
 - [ ] All reviewer comments resolved
-

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -61,3 +61,13 @@ least 16 characters.
 | `GET` | `/api/status` | none | Rendered status section used by HTMX polling. |
 | `POST` | `/incidents` | bearer token | Create an incident. |
 | `POST` | `/incidents/{id}/resolve` | bearer token | Resolve an incident. |
+
+API error responses use a shared JSON envelope:
+
+```json
+{"error":"store error"}
+```
+
+Error responses set `Content-Type: application/json; charset=utf-8`.
+The successful `/api/status` response remains an HTML fragment for HTMX
+polling; only its error responses use the JSON envelope.


### PR DESCRIPTION
## Summary
- Documents the shared JSON API error envelope in the HTTP route reference.
- Notes that successful /api/status responses remain HTML fragments while errors use JSON.
- Adds a PR template Docs impact section and checklist items so documentation review is explicit on every PR.

Docs impact: updates docs/reference.md and .github/pull_request_template.md

## Test plan
- [x] mise run docs-build