### PR TITLE
Polish SQLite store defaults and timestamps

### DIFF
--- a/cmd/northwatch/main.go
+++ b/cmd/northwatch/main.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -26,7 +27,6 @@ import (
 
 const (
 	defaultAddr = ":8080"
-	defaultDB   = "./northwatch.db"
 )
 
 func main() {
@@ -62,7 +62,7 @@ func usage() {
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "serve flags:")
 	fmt.Fprintln(os.Stderr, "  --addr             HTTP listen address (default :8080)")
-	fmt.Fprintln(os.Stderr, "  --db               SQLite database file path (default ./northwatch.db)")
+	fmt.Fprintln(os.Stderr, "  --db               SQLite database file path (default $XDG_DATA_HOME/northwatch/northwatch.db)")
 	fmt.Fprintln(os.Stderr, "  --config           Path to YAML component config (default northwatch.yaml)")
 	fmt.Fprintln(os.Stderr, "  --allow-deactivate Allow boot to deactivate components no longer in --config")
 	fmt.Fprintln(os.Stderr, "  --kubeconfig       Explicit kubeconfig path (overrides in-cluster credentials)")
@@ -79,7 +79,7 @@ func usage() {
 func serveCmd(args []string) int {
 	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
 	addr := fs.String("addr", envOr("NORTHWATCH_ADDR", defaultAddr), "HTTP listen address")
-	dbPath := fs.String("db", envOr("NORTHWATCH_DB", defaultDB), "SQLite database file path")
+	dbPath := fs.String("db", envOr("NORTHWATCH_DB", defaultDBPath()), "SQLite database file path")
 	configPath := fs.String("config",
 		envOr("NORTHWATCH_CONFIG", "northwatch.yaml"),
 		"Path to YAML config declaring watched components")
@@ -144,6 +144,10 @@ func serveCmd(args []string) int {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
+	if err := prepareDBPath(*dbPath); err != nil {
+		logger.Error("prepare store path failed", "err", err, "db", *dbPath)
+		return 1
+	}
 	st, err := store.OpenSQLite(ctx, *dbPath)
 	if err != nil {
 		logger.Error("open store failed", "err", err, "db", *dbPath)
@@ -241,7 +245,7 @@ func serveCmd(args []string) int {
 
 func migrateCmd(args []string) int {
 	fs := flag.NewFlagSet("migrate", flag.ContinueOnError)
-	dbPath := fs.String("db", envOr("NORTHWATCH_DB", defaultDB), "SQLite database file path")
+	dbPath := fs.String("db", envOr("NORTHWATCH_DB", defaultDBPath()), "SQLite database file path")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return 0
@@ -250,9 +254,12 @@ func migrateCmd(args []string) int {
 	}
 
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer stop()
+	ctx := context.Background()
 
+	if err := prepareDBPath(*dbPath); err != nil {
+		logger.Error("prepare store path failed", "err", err, "db", *dbPath)
+		return 1
+	}
 	st, err := store.OpenSQLite(ctx, *dbPath)
 	if err != nil {
 		logger.Error("open store failed", "err", err, "db", *dbPath)
@@ -273,6 +280,28 @@ func envOr(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+func defaultDBPath() string {
+	if dataHome := os.Getenv("XDG_DATA_HOME"); dataHome != "" {
+		return filepath.Join(dataHome, "northwatch", "northwatch.db")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return "./northwatch.db"
+	}
+	return filepath.Join(home, ".local", "share", "northwatch", "northwatch.db")
+}
+
+func prepareDBPath(path string) error {
+	if path == ":memory:" {
+		return nil
+	}
+	dir := filepath.Dir(path)
+	if dir == "." || dir == "" {
+		return nil
+	}
+	return os.MkdirAll(dir, 0o700)
 }
 
 func resolveAPIToken(fs *flag.FlagSet) (string, error) {

--- a/cmd/northwatch/main_test.go
+++ b/cmd/northwatch/main_test.go
@@ -34,6 +34,35 @@ func TestNormalizeAddr(t *testing.T) {
 	}
 }
 
+func TestDefaultDBPath(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", xdg)
+	if got, want := defaultDBPath(), filepath.Join(xdg, "northwatch", "northwatch.db"); got != want {
+		t.Fatalf("defaultDBPath() = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultDBPathFallsBackToUserDataDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("HOME", home)
+	if got, want := defaultDBPath(), filepath.Join(home, ".local", "share", "northwatch", "northwatch.db"); got != want {
+		t.Fatalf("defaultDBPath() = %q, want %q", got, want)
+	}
+}
+
+func TestPrepareDBPathCreatesParent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing", "northwatch.db")
+	if err := prepareDBPath(path); err != nil {
+		t.Fatalf("prepareDBPath: %v", err)
+	}
+	if info, err := os.Stat(filepath.Dir(path)); err != nil {
+		t.Fatalf("Stat parent: %v", err)
+	} else if !info.IsDir() {
+		t.Fatalf("parent is not a directory")
+	}
+}
+
 // testStoreWithMigrate opens an in-memory store with migrations applied.
 func testStoreWithMigrate(t *testing.T) *store.SQLite {
 	t.Helper()

--- a/docs/concepts/data-model.md
+++ b/docs/concepts/data-model.md
@@ -66,8 +66,9 @@ Component status is one of:
 - `degraded`
 - `down`
 
-`updated_at` is written by the store when status is upserted. It tracks
-status update time, not config sync time.
+`updated_at` is written by the store when status is upserted. It is a
+Unix timestamp in milliseconds and tracks status update time, not
+config sync time.
 
 `active` separates current desired components from historical rows.
 When a component disappears from config, `SyncComponents` can
@@ -107,8 +108,9 @@ table on component state transitions.
 ## Persistence behavior
 
 SQLite is the only supported database in v0.1. The binary default path
-is `./northwatch.db`; the container image defaults to
-`/var/lib/northwatch/northwatch.db`.
+is `$XDG_DATA_HOME/northwatch/northwatch.db`, falling back to
+`~/.local/share/northwatch/northwatch.db`. The container image defaults
+to `/var/lib/northwatch/northwatch.db`.
 
 `northwatch serve` applies migrations on startup. `northwatch migrate`
 applies pending migrations and exits, which is useful when an operator

--- a/docs/concepts/overview.md
+++ b/docs/concepts/overview.md
@@ -22,8 +22,8 @@ flowchart LR
 
 The `northwatch` binary supports `serve` and `migrate`. If no subcommand
 is passed, `serve` is used. The server defaults are intentionally
-local-friendly: `:8080` for HTTP, `./northwatch.db` for SQLite, and
-`northwatch.yaml` for config.
+local-friendly: `:8080` for HTTP, the user's XDG data directory for
+SQLite, and `northwatch.yaml` for config.
 
 The component config declares the Kubernetes resources NorthWatch should
 watch. It accepts `Deployment`, Flux `HelmRelease`, Flux

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,7 +43,7 @@ Common `serve` flags:
 | Flag | Environment variable | Default |
 |---|---|---|
 | `--addr` | `NORTHWATCH_ADDR` | `:8080` |
-| `--db` | `NORTHWATCH_DB` | `./northwatch.db` |
+| `--db` | `NORTHWATCH_DB` | `$XDG_DATA_HOME/northwatch/northwatch.db` |
 | `--config` | `NORTHWATCH_CONFIG` | `northwatch.yaml` |
 | `--allow-deactivate` | `NORTHWATCH_ALLOW_DEACTIVATE` | `false` |
 | `--kubeconfig` | `NORTHWATCH_KUBECONFIG` | auto-detected |

--- a/docs/contributing/conventions.md
+++ b/docs/contributing/conventions.md
@@ -65,3 +65,12 @@ namespace prefix exposed to Prometheus, a public HTTP API path prefix.
 
 Conventions that are easy to change later (internal package layout,
 unexported types, log field names) do not belong here.
+
+## SQLite store conventions
+
+SQLite runs with WAL mode, `busy_timeout=5000`, and a connection pool
+limited to 8 open connections. SQLite still serializes writers, but WAL
+allows readers to proceed while one writer holds the write lock. Keep
+the pool small so status-page renders and API reads can run alongside
+watcher writes without encouraging a misleading "more writers equals
+more throughput" tuning path.

--- a/docs/contributing/local-setup.md
+++ b/docs/contributing/local-setup.md
@@ -107,7 +107,9 @@ boot also fails.
 
 ## Database files
 
-The binary default SQLite path is `./northwatch.db`. Pass `--db` or set
+The binary default SQLite path is
+`$XDG_DATA_HOME/northwatch/northwatch.db`, falling back to
+`~/.local/share/northwatch/northwatch.db`. Pass `--db` or set
 `NORTHWATCH_DB` to keep local runs isolated.
 
 The container image defaults to

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -75,8 +75,10 @@ Open <http://localhost:8080>.
 
 ## Database path
 
-The binary default SQLite path is `./northwatch.db`. The container image
-defaults to `/var/lib/northwatch/northwatch.db`.
+The binary default SQLite path is
+`$XDG_DATA_HOME/northwatch/northwatch.db`, falling back to
+`~/.local/share/northwatch/northwatch.db`. The container image defaults
+to `/var/lib/northwatch/northwatch.db`.
 
 The current Helm chart uses `emptyDir` for that directory, so data is
 lost when the pod restarts. PVC support is planned for a later release.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -36,7 +36,7 @@ Subcommands:
 | Flag | Environment variable | Default |
 |---|---|---|
 | `--addr` | `NORTHWATCH_ADDR` | `:8080` |
-| `--db` | `NORTHWATCH_DB` | `./northwatch.db` |
+| `--db` | `NORTHWATCH_DB` | `$XDG_DATA_HOME/northwatch/northwatch.db` |
 | `--config` | `NORTHWATCH_CONFIG` | `northwatch.yaml` |
 | `--allow-deactivate` | `NORTHWATCH_ALLOW_DEACTIVATE` | `false` |
 | `--kubeconfig` | `NORTHWATCH_KUBECONFIG` | auto-detected |

--- a/internal/store/migrations/0003_component_timestamps_millis.down.sql
+++ b/internal/store/migrations/0003_component_timestamps_millis.down.sql
@@ -1,0 +1,3 @@
+UPDATE components
+SET updated_at = updated_at / 1000
+WHERE updated_at >= 1000000000000;

--- a/internal/store/migrations/0003_component_timestamps_millis.up.sql
+++ b/internal/store/migrations/0003_component_timestamps_millis.up.sql
@@ -1,0 +1,4 @@
+UPDATE components
+SET updated_at = updated_at * 1000
+WHERE updated_at > 0
+  AND updated_at < 1000000000000;

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -81,7 +81,7 @@ func (s *SQLite) UpsertComponent(ctx context.Context, c component.Component) err
 	if c.Status == "" {
 		c.Status = component.StatusUnknown
 	}
-	now := time.Now().UTC().Unix()
+	now := time.Now().UTC().UnixMilli()
 	_, err := s.db.ExecContext(ctx, stmtUpsertComponent,
 		c.Kind, c.Namespace, c.Name, c.DisplayName, string(c.Status), now)
 	return err
@@ -109,7 +109,7 @@ func (s *SQLite) GetComponent(ctx context.Context, id string) (component.Compone
 		return component.Component{}, err
 	}
 	c.Status = component.Status(status)
-	c.UpdatedAt = time.Unix(ts, 0).UTC()
+	c.UpdatedAt = time.UnixMilli(ts).UTC()
 	return c, nil
 }
 
@@ -162,7 +162,7 @@ func (s *SQLite) ListComponents(ctx context.Context) ([]component.Component, err
 			return nil, err
 		}
 		c.Status = component.Status(status)
-		c.UpdatedAt = time.Unix(ts, 0).UTC()
+		c.UpdatedAt = time.UnixMilli(ts).UTC()
 		out = append(out, c)
 	}
 	return out, rows.Err()
@@ -216,7 +216,7 @@ func (s *SQLite) SyncComponents(ctx context.Context, specs []ComponentSpec, allo
 	}
 
 	// 5. Upsert all specs.
-	now := time.Now().UTC().Unix()
+	now := time.Now().UTC().UnixMilli()
 	for _, sp := range specs {
 		if _, err := conn.ExecContext(ctx, stmtSyncUpsert,
 			sp.Kind, sp.Namespace, sp.Name, sp.DisplayName, now,

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -51,6 +51,50 @@ func TestMigrateRefusesNewerSchema(t *testing.T) {
 	}
 }
 
+func TestMigrateConvertsComponentUpdatedAtToMillis(t *testing.T) {
+	ctx := context.Background()
+	s, err := store.OpenSQLite(ctx, ":memory:")
+	if err != nil {
+		t.Fatalf("OpenSQLite: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	_, err = s.DB().ExecContext(ctx, `
+CREATE TABLE components (
+  kind         TEXT    NOT NULL CHECK (kind      NOT LIKE '%/%'),
+  namespace    TEXT    NOT NULL CHECK (namespace NOT LIKE '%/%'),
+  name         TEXT    NOT NULL CHECK (name      NOT LIKE '%/%'),
+  id           TEXT    GENERATED ALWAYS AS (kind || '/' || namespace || '/' || name) STORED
+               UNIQUE,
+  display_name TEXT    NOT NULL DEFAULT '',
+  status       TEXT    NOT NULL DEFAULT 'unknown'
+               CHECK (status IN ('unknown','operational','degraded','down')),
+  updated_at   INTEGER NOT NULL,
+  active       INTEGER NOT NULL DEFAULT 1 CHECK (active IN (0, 1))
+) STRICT;
+CREATE TABLE schema_migrations (version uint64, dirty bool);
+INSERT INTO schema_migrations (version, dirty) VALUES (2, 0);
+INSERT INTO components (kind, namespace, name, status, updated_at)
+VALUES ('Deployment', 'default', 'web', 'operational', 1710000000);
+`)
+	if err != nil {
+		t.Fatalf("seed v2 schema: %v", err)
+	}
+
+	if err := s.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	var got int64
+	if err := s.DB().QueryRowContext(ctx,
+		`SELECT updated_at FROM components WHERE id = 'Deployment/default/web'`).Scan(&got); err != nil {
+		t.Fatalf("query updated_at: %v", err)
+	}
+	if want := int64(1710000000000); got != want {
+		t.Fatalf("updated_at = %d, want %d", got, want)
+	}
+}
+
 func seedComponent(t *testing.T, s *store.SQLite, c component.Component) {
 	t.Helper()
 	if err := s.UpsertComponent(context.Background(), c); err != nil {
@@ -114,7 +158,16 @@ func TestUpsertIsIdempotent(t *testing.T) {
 	seedComponent(t, s, c)
 	first, _ := s.GetComponent(ctx, c.ID())
 
-	time.Sleep(time.Second + 50*time.Millisecond)
+	_, err := s.DB().ExecContext(ctx,
+		`UPDATE components SET updated_at = ? WHERE id = ?`,
+		first.UpdatedAt.Add(-time.Second).UnixMilli(), c.ID())
+	if err != nil {
+		t.Fatalf("force old updated_at: %v", err)
+	}
+	first, err = s.GetComponent(ctx, c.ID())
+	if err != nil {
+		t.Fatalf("GetComponent after timestamp reset: %v", err)
+	}
 
 	c.DisplayName = "Web (renamed)"
 	c.Status = component.StatusDegraded

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -84,7 +84,7 @@ type Store interface {
 
 	// UpsertComponent inserts or updates by id. The store computes id
 	// from (Kind, Namespace, Name) — SQLite uses a STORED generated
-	// column — and stamps updated_at to time.Now().UTC().Unix().
+	// column — and stamps updated_at to time.Now().UTC().UnixMilli().
 	UpsertComponent(ctx context.Context, c component.Component) error
 
 	// SyncComponents reconciles the components table against the


### PR DESCRIPTION
## Summary
- Store component updated_at values in milliseconds and migrate existing second-based component rows forward.
- Resolve the default SQLite path through XDG data directories, creating parent directories from the CLI before opening the DB.
- Drop the migrate command's cosmetic signal context and document the SQLite pool-size rationale.

Docs impact: updated database-path docs, data-model timestamp docs, and contributor SQLite pool guidance.

Closes #31

## Test plan
- [x] env GOCACHE=/private/tmp/northwatch-go-cache go test ./cmd/northwatch ./internal/store
- [x] env GOCACHE=/private/tmp/northwatch-go-cache go test ./...
- [x] mise run docs-build