### PR TITLE
Point README to published docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,9 +209,10 @@ The roadmap for v0.2.0+ (Postgres, external HTTP monitors,
 notifications, CLI, OCI-published chart) lives in the
 [GitHub milestones](https://github.com/northwatchlabs/northwatch/milestones).
 
-User documentation starts in [`docs/index.md`](docs/index.md): getting
-started, installation, configuration, operations, concepts, and
-reference.
+Customer-facing documentation is published at
+<https://northwatchlabs.github.io/northwatch/>. The source lives in
+[`docs/index.md`](docs/index.md): getting started, installation,
+configuration, operations, concepts, and reference.
 
 Contributor documentation starts in
 [`docs/contributing/index.md`](docs/contributing/index.md). See


### PR DESCRIPTION
## Summary
- Point README users to the published customer-facing documentation site.
- Keep the repo-local `docs/index.md` source reference for contributors.

Docs impact: README documentation link updated.

## Test plan
- [x] `mise run docs-build`