### PR TITLE
Split health and readiness checks

### DIFF
--- a/cmd/northwatch/main.go
+++ b/cmd/northwatch/main.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -28,6 +29,11 @@ import (
 const (
 	defaultAddr = ":8080"
 )
+
+type syncedWatcher interface {
+	Start(context.Context) error
+	Synced() <-chan struct{}
+}
 
 func main() {
 	if len(os.Args) < 2 {
@@ -171,7 +177,21 @@ func serveCmd(args []string) int {
 		return 1
 	}
 
-	h, err := server.New(logger, st, *apiToken, *pollSeconds)
+	var watcherMu sync.RWMutex
+	var watchers []syncedWatcher
+	watcherRegistrationComplete := make(chan struct{})
+	if kc == nil {
+		close(watcherRegistrationComplete)
+	}
+
+	h, err := server.New(logger, st, *apiToken, *pollSeconds, server.Readiness{
+		WatcherRegistrationComplete: watcherRegistrationComplete,
+		WatcherSyncedFunc: func() []<-chan struct{} {
+			watcherMu.RLock()
+			defer watcherMu.RUnlock()
+			return watcherSyncedChannels(watchers)
+		},
+	})
 	if err != nil {
 		logger.Error("server init failed", "err", err)
 		return 1
@@ -196,33 +216,33 @@ func serveCmd(args []string) int {
 		errCh <- srv.ListenAndServe()
 	}()
 	if kc != nil {
-		depWatcher := watcher.NewDeploymentWatcher(kc.Clientset, st, cfg.Components, logger, window, clock.RealClock{})
 		go func() {
-			if err := depWatcher.Start(ctx); err != nil {
-				errCh <- err
+			discovered := []syncedWatcher{
+				watcher.NewDeploymentWatcher(kc.Clientset, st, cfg.Components, logger, window, clock.RealClock{}),
+			}
+			if hrWatcher := buildHelmReleaseWatcher(ctx, kc, st, cfg.Components, logger, window, clock.RealClock{}); hrWatcher != nil {
+				discovered = append(discovered, hrWatcher)
+			}
+			if appWatcher := buildApplicationWatcher(ctx, kc, st, cfg.Components, logger, window, clock.RealClock{}); appWatcher != nil {
+				discovered = append(discovered, appWatcher)
+			}
+			if ksWatcher := buildKustomizationWatcher(ctx, kc, st, cfg.Components, logger, window, clock.RealClock{}); ksWatcher != nil {
+				discovered = append(discovered, ksWatcher)
+			}
+
+			watcherMu.Lock()
+			watchers = discovered
+			watcherMu.Unlock()
+			close(watcherRegistrationComplete)
+
+			for _, w := range discovered {
+				go func(w syncedWatcher) {
+					if err := w.Start(ctx); err != nil {
+						errCh <- err
+					}
+				}(w)
 			}
 		}()
-		if hrWatcher := buildHelmReleaseWatcher(ctx, kc, st, cfg.Components, logger, window, clock.RealClock{}); hrWatcher != nil {
-			go func() {
-				if err := hrWatcher.Start(ctx); err != nil {
-					errCh <- err
-				}
-			}()
-		}
-		if appWatcher := buildApplicationWatcher(ctx, kc, st, cfg.Components, logger, window, clock.RealClock{}); appWatcher != nil {
-			go func() {
-				if err := appWatcher.Start(ctx); err != nil {
-					errCh <- err
-				}
-			}()
-		}
-		if ksWatcher := buildKustomizationWatcher(ctx, kc, st, cfg.Components, logger, window, clock.RealClock{}); ksWatcher != nil {
-			go func() {
-				if err := ksWatcher.Start(ctx); err != nil {
-					errCh <- err
-				}
-			}()
-		}
 	}
 
 	select {
@@ -441,6 +461,14 @@ func runClusterInit(
 		KubeContext:    kubeContext,
 		Logger:         logger,
 	})
+}
+
+func watcherSyncedChannels(watchers []syncedWatcher) []<-chan struct{} {
+	channels := make([]<-chan struct{}, 0, len(watchers))
+	for _, w := range watchers {
+		channels = append(channels, w.Synced())
+	}
+	return channels
 }
 
 // buildHelmReleaseWatcher probes for the Flux HelmRelease CRD and

--- a/cmd/northwatch/main_test.go
+++ b/cmd/northwatch/main_test.go
@@ -116,6 +116,38 @@ func captureStdout(t *testing.T, fn func()) string {
 	return string(out)
 }
 
+type testSyncedWatcher struct {
+	ch <-chan struct{}
+}
+
+func (w testSyncedWatcher) Start(context.Context) error { return nil }
+func (w testSyncedWatcher) Synced() <-chan struct{}     { return w.ch }
+
+func TestWatcherSyncedChannels(t *testing.T) {
+	first := make(chan struct{})
+	second := make(chan struct{})
+
+	got := watcherSyncedChannels([]syncedWatcher{
+		testSyncedWatcher{ch: first},
+		testSyncedWatcher{ch: second},
+	})
+
+	if len(got) != 2 {
+		t.Fatalf("len(got) = %d, want 2", len(got))
+	}
+	close(first)
+	select {
+	case <-got[0]:
+	default:
+		t.Fatal("first channel was not preserved")
+	}
+	select {
+	case <-got[1]:
+		t.Fatal("second channel should still be open")
+	default:
+	}
+}
+
 const cfgAB = `
 components:
   - kind: Deployment

--- a/deploy/helm/northwatch/templates/deployment.yaml
+++ b/deploy/helm/northwatch/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
             periodSeconds: 10
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: /readyz
               port: http
             initialDelaySeconds: 2
             periodSeconds: 5

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -66,7 +66,8 @@ it into a distroless non-root runtime image, and defaults SQLite to:
 The in-tree chart lives at `deploy/helm/northwatch`. Chart verification
 uses `helm lint`, builds a matching NorthWatch image from the chart
 `appVersion`, installs the chart into kind, waits for the deployment,
-checks `/healthz`, checks component status through `/api/components`,
+checks `/healthz`, waits on the `/readyz` readiness probe through the
+deployment, checks component status through `/api/components`,
 and verifies cluster-scoped RBAC is removed on uninstall.
 
 The project convention for the future OCI chart path is:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -9,11 +9,17 @@ NorthWatch exposes:
 
 ```text
 GET /healthz
+GET /readyz
 ```
 
-The endpoint returns `200 OK` with `ok` when the HTTP process is
-running. It does not prove every configured Kubernetes watcher has
-observed its resource.
+`/healthz` returns `200 OK` with `ok` when the HTTP process is running.
+It is the liveness check used by the Helm chart.
+
+`/readyz` returns `200 OK` only when the store is reachable and every
+registered Kubernetes watcher has completed its initial cache sync. The
+Helm chart uses `/readyz` for readiness so Service traffic waits for the
+first trusted watcher snapshot. Local runs with `--no-cluster` have no
+watcher sync dependency, so readiness only checks the store.
 
 ## Status refresh
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -56,6 +56,7 @@ least 16 characters.
 |---|---|---|---|
 | `GET` | `/` | none | Public status page. |
 | `GET` | `/healthz` | none | Process health check. |
+| `GET` | `/readyz` | none | Readiness check. Requires store reachability and initial watcher sync. |
 | `GET` | `/api/components` | none | JSON component list. |
 | `GET` | `/api/incidents` | none | Active incidents by default. Use `?include=resolved` to include resolved incidents. |
 | `GET` | `/api/status` | none | Rendered status section used by HTMX polling. |

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -29,6 +29,13 @@ type pageData struct {
 	PollSeconds    int
 }
 
+// Readiness configures /readyz dependencies beyond process liveness.
+type Readiness struct {
+	WatcherRegistrationComplete <-chan struct{}
+	WatcherSynced               []<-chan struct{}
+	WatcherSyncedFunc           func() []<-chan struct{}
+}
+
 // New returns an http.Handler with routes for the status page,
 // healthcheck, embedded static assets, and bearer-token-protected
 // write endpoints. The store is consulted on every index render.
@@ -36,7 +43,7 @@ type pageData struct {
 // apiToken gates POST routes. An empty token boots the server with
 // the write side disabled — every POST returns 401. Reads remain
 // public regardless of token state.
-func New(logger *slog.Logger, st store.Store, apiToken string, pollSeconds int) (http.Handler, error) {
+func New(logger *slog.Logger, st store.Store, apiToken string, pollSeconds int, readiness Readiness) (http.Handler, error) {
 	tmpl, err := ui.Templates()
 	if err != nil {
 		return nil, err
@@ -55,6 +62,7 @@ func New(logger *slog.Logger, st store.Store, apiToken string, pollSeconds int) 
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok\n"))
 	})
+	r.Get("/readyz", readyzHandler(st, readiness))
 
 	incSvc := incident.NewService(st, logger)
 
@@ -71,6 +79,37 @@ func New(logger *slog.Logger, st store.Store, apiToken string, pollSeconds int) 
 	})
 
 	return r, nil
+}
+
+func readyzHandler(st store.Store, ready Readiness) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := st.Ping(r.Context()); err != nil {
+			http.Error(w, "not ready", http.StatusServiceUnavailable)
+			return
+		}
+		if ready.WatcherRegistrationComplete != nil {
+			select {
+			case <-ready.WatcherRegistrationComplete:
+			default:
+				http.Error(w, "not ready", http.StatusServiceUnavailable)
+				return
+			}
+		}
+		syncedChannels := ready.WatcherSynced
+		if ready.WatcherSyncedFunc != nil {
+			syncedChannels = ready.WatcherSyncedFunc()
+		}
+		for _, synced := range syncedChannels {
+			select {
+			case <-synced:
+			default:
+				http.Error(w, "not ready", http.StatusServiceUnavailable)
+				return
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok\n"))
+	}
 }
 
 func indexHandler(tmpl *template.Template, st store.Store, incSvc *incident.Service, pollSeconds int, logger *slog.Logger) http.HandlerFunc {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -43,7 +43,7 @@ func newHandlerWith(t *testing.T, token string, seed ...component.Component) (ht
 			t.Fatalf("UpsertComponent: %v", err)
 		}
 	}
-	h, err := server.New(slog.New(slog.NewTextHandler(io.Discard, nil)), st, token, 5)
+	h, err := server.New(slog.New(slog.NewTextHandler(io.Discard, nil)), st, token, 5, server.Readiness{})
 	if err != nil {
 		t.Fatalf("server.New: %v", err)
 	}
@@ -57,6 +57,20 @@ func newHandler(t *testing.T, seed ...component.Component) http.Handler {
 	t.Helper()
 	h, _ := newHandlerWith(t, "", seed...)
 	return h
+}
+
+func testSQLiteStore(t *testing.T) *store.SQLite {
+	t.Helper()
+	ctx := context.Background()
+	st, err := store.OpenSQLite(ctx, ":memory:")
+	if err != nil {
+		t.Fatalf("OpenSQLite: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	return st
 }
 
 func assertJSONError(t *testing.T, rr *httptest.ResponseRecorder, code int, msg string) {
@@ -137,6 +151,97 @@ func TestHealthz(t *testing.T) {
 	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/healthz", nil))
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+}
+
+func TestReadyzWaitsForWatcherSync(t *testing.T) {
+	st := testSQLiteStore(t)
+	synced := make(chan struct{})
+	h, err := server.New(slog.New(slog.NewTextHandler(io.Discard, nil)), st, "", 5, server.Readiness{
+		WatcherSynced: []<-chan struct{}{synced},
+	})
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status before sync = %d, want 503", rr.Code)
+	}
+
+	close(synced)
+	rr = httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status after sync = %d, want 200", rr.Code)
+	}
+}
+
+func TestReadyzWaitsForWatcherRegistration(t *testing.T) {
+	st := testSQLiteStore(t)
+	registrationComplete := make(chan struct{})
+	h, err := server.New(slog.New(slog.NewTextHandler(io.Discard, nil)), st, "", 5, server.Readiness{
+		WatcherRegistrationComplete: registrationComplete,
+	})
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status before watcher registration = %d, want 503", rr.Code)
+	}
+
+	close(registrationComplete)
+	rr = httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status after watcher registration = %d, want 200", rr.Code)
+	}
+}
+
+func TestReadyzReadsDynamicWatcherSyncState(t *testing.T) {
+	st := testSQLiteStore(t)
+	synced := make(chan struct{})
+	h, err := server.New(slog.New(slog.NewTextHandler(io.Discard, nil)), st, "", 5, server.Readiness{
+		WatcherSyncedFunc: func() []<-chan struct{} {
+			return []<-chan struct{}{synced}
+		},
+	})
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status before dynamic sync = %d, want 503", rr.Code)
+	}
+
+	close(synced)
+	rr = httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status after dynamic sync = %d, want 200", rr.Code)
+	}
+}
+
+func TestReadyzRequiresReachableStore(t *testing.T) {
+	st := testSQLiteStore(t)
+	if err := st.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	h, err := server.New(slog.New(slog.NewTextHandler(io.Discard, nil)), st, "", 5, server.Readiness{})
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rr.Code)
 	}
 }
 
@@ -261,7 +366,7 @@ func TestAPIComponents_StoreError(t *testing.T) {
 		t.Fatalf("Migrate: %v", err)
 	}
 	h, err := server.New(slog.New(slog.NewTextHandler(io.Discard, nil)),
-		failingStore{Store: real}, "", 5)
+		failingStore{Store: real}, "", 5, server.Readiness{})
 	if err != nil {
 		t.Fatalf("server.New: %v", err)
 	}
@@ -387,7 +492,7 @@ func TestGetAPIIncidents_StoreError(t *testing.T) {
 		t.Fatalf("Migrate: %v", err)
 	}
 	h, err := server.New(slog.New(slog.NewTextHandler(io.Discard, nil)),
-		failingIncidentListStore{Store: real}, "", 5)
+		failingIncidentListStore{Store: real}, "", 5, server.Readiness{})
 	if err != nil {
 		t.Fatalf("server.New: %v", err)
 	}
@@ -505,7 +610,7 @@ func TestCreateIncidentHandler_StoreError(t *testing.T) {
 		t.Fatalf("Migrate: %v", err)
 	}
 	h, err := server.New(slog.New(slog.NewTextHandler(io.Discard, nil)),
-		failingCreateIncidentStore{Store: real}, testToken, 5)
+		failingCreateIncidentStore{Store: real}, testToken, 5, server.Readiness{})
 	if err != nil {
 		t.Fatalf("server.New: %v", err)
 	}
@@ -648,7 +753,7 @@ func TestResolveIncidentHandler_StoreError(t *testing.T) {
 		t.Fatalf("Migrate: %v", err)
 	}
 	h, err := server.New(slog.New(slog.NewTextHandler(io.Discard, nil)),
-		failingResolveIncidentStore{Store: real}, testToken, 5)
+		failingResolveIncidentStore{Store: real}, testToken, 5, server.Readiness{})
 	if err != nil {
 		t.Fatalf("server.New: %v", err)
 	}
@@ -769,7 +874,7 @@ func TestIndex_BannerIncidentTakesPriority(t *testing.T) {
 	if _, err := incSvc.CreateIncident(ctx, comp.ID(), "Demo outage"); err != nil {
 		t.Fatalf("CreateIncident: %v", err)
 	}
-	h, err := server.New(slog.New(slog.NewTextHandler(io.Discard, nil)), st, "", 5)
+	h, err := server.New(slog.New(slog.NewTextHandler(io.Discard, nil)), st, "", 5, server.Readiness{})
 	if err != nil {
 		t.Fatalf("server.New: %v", err)
 	}
@@ -836,7 +941,7 @@ func TestApiStatus_StoreError(t *testing.T) {
 		t.Fatalf("Migrate: %v", err)
 	}
 	h, err := server.New(slog.New(slog.NewTextHandler(io.Discard, nil)),
-		failingStore{Store: real}, "", 5)
+		failingStore{Store: real}, "", 5, server.Readiness{})
 	if err != nil {
 		t.Fatalf("server.New: %v", err)
 	}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -53,6 +53,9 @@ func OpenSQLite(ctx context.Context, path string) (*SQLite, error) {
 // Close releases the underlying connection pool.
 func (s *SQLite) Close() error { return s.db.Close() }
 
+// Ping verifies the SQLite connection pool is reachable.
+func (s *SQLite) Ping(ctx context.Context) error { return s.db.PingContext(ctx) }
+
 // DB exposes the underlying *sql.DB for tests in this package only.
 // Production callers should never reach for this.
 func (s *SQLite) DB() *sql.DB { return s.db }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -59,6 +59,9 @@ type Store interface {
 	// Close releases the underlying connection pool. Safe to call once.
 	Close() error
 
+	// Ping verifies the store is reachable.
+	Ping(ctx context.Context) error
+
 	// Migrate brings the schema to the version embedded in this binary.
 	// Idempotent. Returns ErrSchemaTooNew if the DB on disk is already
 	// at a higher version than this binary supports. The ctx parameter

--- a/internal/watcher/deployment_test.go
+++ b/internal/watcher/deployment_test.go
@@ -47,6 +47,7 @@ func newRecordStore() *recordStore {
 }
 
 func (s *recordStore) Close() error                  { return nil }
+func (s *recordStore) Ping(context.Context) error    { return nil }
 func (s *recordStore) Migrate(context.Context) error { return nil }
 func (s *recordStore) ListComponents(context.Context) ([]component.Component, error) {
 	return nil, nil


### PR DESCRIPTION
## Summary
- Add /readyz so readiness checks store reachability, watcher registration, and initial watcher cache sync.
- Start the HTTP server before optional watcher CRD discovery so /healthz remains process-only liveness during slow cluster discovery.
- Move the Helm readiness probe to /readyz while leaving liveness on /healthz.

Docs impact: updated operations, HTTP reference, and release-process docs for /readyz behavior.

Closes #72

## Test plan
- [x] git diff --check HEAD~1..HEAD
- [x] env GOCACHE=/private/tmp/northwatch-go-cache go test ./...
- [x] helm lint deploy/helm/northwatch
- [x] helm template northwatch deploy/helm/northwatch | rg "path: /(healthz|readyz)"
- [x] mise run docs-build